### PR TITLE
Update Kokkos to 3.7.00 version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,9 @@
  * Add tests for MacOS.
   [(#3)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/3)
 
+ * Upgrade Kokkos Core to 3.7.00.
+  [(#3)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/7)
+
 ### Documentation
 
 ### Bug fixes

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Install lightning.kokkos device
         run: |
           cd main
-          python setup.py build_ext -i --define="Kokkos_ENABLE_${{ matrix.exec_model }}=ON;CMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++"
-          pip install -e .
+          CXX=$(which g++-10) BACKEND=${{ matrix.exec_model }} python -m pip install -e . --verbose
+
       - name: Run PennyLane-Lightning unit tests
         run: |
           cd main/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ option(Kokkos_ENABLE_DEPRECATION_WARNINGS "Enable Kokkos deprecation warnings" O
 include(FetchContent)
 FetchContent_Declare(kokkos
   GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-  GIT_TAG        3.6.00
+  GIT_TAG        3.7.00
 )
 FetchContent_MakeAvailable(kokkos)
 get_target_property(PLKOKKOS_KOKKOS_INC_DIR kokkos INTERFACE_INCLUDE_DIRECTORIES)

--- a/pennylane_lightning_kokkos/_version.py
+++ b/pennylane_lightning_kokkos/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.27.0-dev1"
+__version__ = "0.27.0-dev2"


### PR DESCRIPTION
**Context:**
Kokkos 3.7.0.0 was released https://github.com/kokkos/kokkos/blob/master/CHANGELOG.md and includes updates for Ponte Veccio and a range of bugfixes and improvements for other backends. We should update the pinned version to directly allow use of these.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** #6
