### PR TITLE
Downgrade Numpy to avoid conflicts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,11 +13,14 @@
 
 ### Bug fixes
 
+* Limit Numpy version to avoid conflicts with Autograd.
+[(#34)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/34)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Shuli Shu
+Amintor Dusko, Shuli Shu
 
 ---
 

--- a/pennylane_lightning_kokkos/_version.py
+++ b/pennylane_lightning_kokkos/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev"
+__version__ = "0.29.0-dev1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ninja
 cmake
 flaky
-numpy
+numpy<1.24
 pennylane>=0.25
 pennylane-lightning>=0.25
 pybind11

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ requirements = [
     "ninja",
     "wheel",
     "cmake",
-    "numpy",
+    "numpy<1.24",
     "pennylane-lightning>=0.22",
     "pennylane>=0.22",
 ]


### PR DESCRIPTION
**Context:** Numpy last minor version 1.24 has some conflicts with Autograd.

**Description of the Change:** For now we'll limit installation to Numpy < 1.24

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
