### PR TITLE
Remove explicit Numpy requirement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,12 +9,12 @@
 * Update `inv()` methods in Python unit tests with `qml.adjoint()`.
 [(#33)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/33)
 
+* Remove explicit Numpy dependence.
+[(#35)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/35)
+
 ### Documentation
 
 ### Bug fixes
-
-* Limit Numpy version to avoid conflicts with Autograd.
-[(#34)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/34)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Update `inv()` methods in Python unit tests with `qml.adjoint()`.
 [(#33)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/33)
 
-* Remove explicit Numpy dependence.
+* Remove explicit Numpy requirement.
 [(#35)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/35)
 
 ### Documentation

--- a/pennylane_lightning_kokkos/_version.py
+++ b/pennylane_lightning_kokkos/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev1"
+__version__ = "0.29.0-dev2"

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -168,7 +168,6 @@ class LightningKokkos(LightningQubit):
                 method(wires, inv, param)
 
     def apply(self, operations, **kwargs):
-
         # State preparation is currently done in Python
         if operations:  # make sure operations[0] exists
             if isinstance(operations[0], QubitStateVector):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 ninja
 cmake
 flaky
-numpy<1.24
-pennylane>=0.25
-pennylane-lightning>=0.25
+pennylane>=0.28
+pennylane-lightning>=0.28
 pybind11
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -139,9 +139,8 @@ requirements = [
     "ninja",
     "wheel",
     "cmake",
-    "numpy<1.24",
-    "pennylane-lightning>=0.22",
-    "pennylane>=0.22",
+    "pennylane-lightning>=0.28",
+    "pennylane>=0.28",
 ]
 
 info = {

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -43,7 +43,6 @@ class TestDenseMatrixDecompositionThreshold:
 
     @pytest.mark.parametrize("op, n_wires, condition", input)
     def test_threshold(self, op, n_wires, condition):
-
         wires = np.linspace(0, n_wires - 1, n_wires, dtype=int)
         op = op(wires=wires)
         assert LightningKokkos.stopping_condition.__get__(op)(op) == condition

--- a/tests/test_hamiltonian.py
+++ b/tests/test_hamiltonian.py
@@ -52,7 +52,6 @@ class TestHamiltonianExpval:
         assert np.allclose(circuit(), res, atol=tol, rtol=0)
 
     def test_hamiltonan_expectation(self, qubit_device_3_wires, tol):
-
         dev = qubit_device_3_wires
 
         obs = qml.PauliX(1) @ qml.PauliY(2)

--- a/tests/test_hamiltonian_sparse.py
+++ b/tests/test_hamiltonian_sparse.py
@@ -26,7 +26,6 @@ class TestSparseHamiltonianExpval:
     """Tests for the expval function"""
 
     def test_sparse_hamiltionan_expval(self, qubit_device_3_wires, tol):
-
         dev = LightningKokkos(wires=3, c_dtype=np.complex128)
         obs = qml.Identity(0) @ qml.PauliX(1) @ qml.PauliY(2)
 


### PR DESCRIPTION
**Context:** PennyLane is a hard dependence and already provides Numpy as a requirement.

**Description of the Change:** Remove explicit Numpy and Scipy dependence

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
