### PR TITLE
Remove use of `inverse` property

### DIFF
--- a/pennylane_lightning_kokkos/_serialize.py
+++ b/pennylane_lightning_kokkos/_serialize.py
@@ -26,6 +26,7 @@ from pennylane import (
 )
 from pennylane.grouping import is_pauli_word
 from pennylane.operation import Observable, Tensor
+from pennylane.ops.op_math.adjoint import Adjoint
 from pennylane.tape import QuantumTape
 
 # Remove after the next release of PL
@@ -153,7 +154,7 @@ def _serialize_ops(
             op_list = [o]
 
         for single_op in op_list:
-            is_inverse = single_op.inverse
+            is_inverse = isinstance(single_op, Adjoint)
 
             name = single_op.name if not is_inverse else single_op.name[:-4]
             names.append(name)

--- a/pennylane_lightning_kokkos/_serialize.py
+++ b/pennylane_lightning_kokkos/_serialize.py
@@ -26,7 +26,7 @@ from pennylane import (
 )
 from pennylane.grouping import is_pauli_word
 from pennylane.operation import Observable, Tensor
-from pennylane.ops.op_math.adjoint import Adjoint
+from pennylane.ops.op_math import Adjoint
 from pennylane.tape import QuantumTape
 
 # Remove after the next release of PL

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -34,7 +34,7 @@ from pennylane import (
 )
 from pennylane_lightning import LightningQubit
 from pennylane.operation import Tensor, Operation
-from pennylane.ops.op_math.adjoint import Adjoint
+from pennylane.ops.op_math import Adjoint
 from pennylane.measurements import Expectation
 from pennylane.wires import Wires
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -34,6 +34,7 @@ from pennylane import (
 )
 from pennylane_lightning import LightningQubit
 from pennylane.operation import Tensor, Operation
+from pennylane.ops.op_math.adjoint import Adjoint
 from pennylane.measurements import Expectation
 from pennylane.wires import Wires
 
@@ -160,15 +161,19 @@ class LightningKokkos(LightningQubit):
 
         return qml.BooleanFn(accepts_obj)
 
-    def apply_cq(self, operations, **kwargs):
+    def apply_kokkos(self, operations, **kwargs):
         # Skip over identity operations instead of performing
         # matrix multiplication with the identity.
         skipped_ops = ["Identity"]
+        invert_param = False
 
         for o in operations:
             if o.base_name in skipped_ops:
                 continue
-            name = o.name.split(".")[0]  # The split is because inverse gates have .inv appended
+            name = o.name
+            if isinstance(o, Adjoint):
+                name = o.base.name
+                invert_param = True
             method = getattr(self._kokkos_state, name, None)
 
             wires = self.wires.indices(o.wires)
@@ -192,9 +197,8 @@ class LightningKokkos(LightningQubit):
                 )  # Parameters can be ignored for explicit matrices; F-order for cuQuantum
 
             else:
-                inv = o.inverse
                 param = o.parameters
-                method(wires, inv, param)
+                method(wires, invert_param, param)
 
     def apply(self, operations, **kwargs):
         # State preparation is currently done in Python
@@ -215,7 +219,7 @@ class LightningKokkos(LightningQubit):
                     "applied on a {} device.".format(operation.name, self.short_name)
                 )
 
-        self.apply_cq(operations)
+        self.apply_kokkos(operations)
 
         if self._sync:
             self.syncD2H()

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -381,15 +381,10 @@ class TestAdjointJacobianQNode:
 
         dev = qml.device("lightning.kokkos", wires=1, shots=1)
 
-        with pytest.warns(
-            UserWarning,
-            match="Requested adjoint differentiation to be computed with finite shots.",
-        ):
-
-            @qml.qnode(dev, diff_method="adjoint")
-            def circ(x):
-                qml.RX(x, wires=0)
-                return qml.expval(qml.PauliZ(0))
+        @qml.qnode(dev, diff_method="adjoint")
+        def circ(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
             UserWarning,

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -379,18 +379,23 @@ class TestAdjointJacobianQNode:
     def test_finite_shots_warning(self):
         """Tests that a warning is raised when computing the adjoint diff on a device with finite shots"""
 
+        param = qml.numpy.array(0.1)
         dev = qml.device("lightning.kokkos", wires=1, shots=1)
+        with pytest.warns(
+            UserWarning,
+            match="Requested adjoint differentiation to be computed with finite shots.",
+        ):
 
-        @qml.qnode(dev, diff_method="adjoint")
-        def circ(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            @qml.qnode(dev, diff_method="adjoint")
+            def circ(x):
+                qml.RX(x, wires=0)
+                return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
             UserWarning,
             match="Requested adjoint differentiation to be computed with finite shots.",
         ):
-            qml.grad(circ)(0.1)
+            qml.grad(circ)(param)
 
     def test_qnode(self, mocker, tol, dev_kokkos):
         """Test that specifying diff_method allows the adjoint method to be selected"""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** PennyLane recently fully [removed](https://github.com/PennyLaneAI/pennylane/pull/3725) the `.inverse` operator property. This PR updates the support to ensure the same functionality with tests for the `Adjoint` class instance.

**Description of the Change:** Removes `.inverse` from serialisation and op pipeline, and replaces with instance checks for `Adjoint` types.

**Benefits:** Ensures compatibility with PennyLane 0.29.x

**Possible Drawbacks:**

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane/pull/3725
