### PR TITLE
fix failures of pl_device_test with shots set

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,6 +35,9 @@
 * Fix the CI environment variables for building wheels with the OpenMP backend.
 [(#36)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/36)
 
+* Fix the failures of pl_device_test tests with shots set.
+[(#38)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/38)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -81,7 +81,7 @@ jobs:
           cd main/
           pytest tests/
           pl-device-test --device lightning.kokkos --skip-ops --shots=20000
-          pl-device-test --device lightning.kokkos --shots=None --skip-ops
+          pl-device-test --device lightning.kokkos --skip-ops --shots=None
   cpptests_serial:
     name: C++ tests (Linux) for Serial Kokkos backend
     runs-on: ${{ matrix.os }}
@@ -149,4 +149,4 @@ jobs:
           cd main/
           pytest tests/
           pl-device-test --device lightning.kokkos --skip-ops --shots=20000
-          pl-device-test --device lightning.kokkos --shots=None --skip-ops
+          pl-device-test --device lightning.kokkos --skip-ops --shots=None

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -80,7 +80,8 @@ jobs:
         run: |
           cd main/
           pytest tests/
-          pl-device-test --device lightning.kokkos
+          pl-device-test --device lightning.kokkos --skip-ops --shots=20000
+          pl-device-test --device lightning.kokkos --shots=None --skip-ops
   cpptests_serial:
     name: C++ tests (Linux) for Serial Kokkos backend
     runs-on: ${{ matrix.os }}
@@ -147,4 +148,5 @@ jobs:
         run: |
           cd main/
           pytest tests/
-          pl-device-test --device lightning.kokkos
+          pl-device-test --device lightning.kokkos --skip-ops --shots=20000
+          pl-device-test --device lightning.kokkos --shots=None --skip-ops

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Run PennyLane-Lightning-Kokkos unit tests
         run: |
           pytest ./tests/
-          pl-device-test --device lightning.kokkos
+          pl-device-test --device lightning.kokkos --skip-ops --shots=20000
+          pl-device-test --device lightning.kokkos --skip-ops --shots=None
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -93,4 +93,4 @@ jobs:
           cd main/
           pytest tests/
           pl-device-test --device lightning.kokkos --skip-ops --shots=20000
-          pl-device-test --device lightning.kokkos --shots=None --skip-ops
+          pl-device-test --device lightning.kokkos --skip-ops --shots=None

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -92,4 +92,5 @@ jobs:
         run: |
           cd main/
           pytest tests/
-          pl-device-test --device lightning.kokkos
+          pl-device-test --device lightning.kokkos --skip-ops --shots=20000
+          pl-device-test --device lightning.kokkos --shots=None --skip-ops

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -287,6 +287,14 @@ class LightningKokkos(LightningQubit):
 
         return self._kokkos_state.probs(device_wires)
 
+    def sample(self, observable, shot_range=None, bin_size=None, counts=False):
+        if observable.name != "PauliZ":
+            self.apply_cq(observable.diagonalizing_gates())
+            self._samples = self.generate_samples()
+        return super().sample(
+            observable, shot_range=shot_range, bin_size=bin_size, counts=counts
+        )
+
     def expval(self, observable, shot_range=None, bin_size=None):
         if observable.name in [
             "Projector",

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -291,9 +291,7 @@ class LightningKokkos(LightningQubit):
         if observable.name != "PauliZ":
             self.apply_cq(observable.diagonalizing_gates())
             self._samples = self.generate_samples()
-        return super().sample(
-            observable, shot_range=shot_range, bin_size=bin_size, counts=counts
-        )
+        return super().sample(observable, shot_range=shot_range, bin_size=bin_size, counts=counts)
 
     def expval(self, observable, shot_range=None, bin_size=None):
         if observable.name in [

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -289,7 +289,7 @@ class LightningKokkos(LightningQubit):
 
     def sample(self, observable, shot_range=None, bin_size=None, counts=False):
         if observable.name != "PauliZ":
-            self.apply_cq(observable.diagonalizing_gates())
+            self.apply_kokkos(observable.diagonalizing_gates())
             self._samples = self.generate_samples()
         return super().sample(observable, shot_range=shot_range, bin_size=bin_size, counts=counts)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Currently there are failures when running pl_device_test with shots set with a certain number. Following the Lightning-GPU implementation, `sample()` is added to the python layer to fix this issue.

**Description of the Change:**

**Benefits:**

Avoid failures when running pl_device_test with shots set with a certain number.

**Possible Drawbacks:**

**Related GitHub Issues:**
