### PR TITLE
Template n-qbit gate methods.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Template n-qubit gate methods.
+[(#40)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/40)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Vincent Michaud-Rioux
 
 ---
 
@@ -41,9 +46,6 @@ This release contains contributions from (in alphabetical order):
 [(#31)] (https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/31)
 
 ### Improvements
-
-* Template n-qubit gate methods.
-[(#40)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/40)
 
 * Update `inv()` methods in Python unit tests with `qml.adjoint()`.
 [(#33)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/33)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,19 +5,24 @@
  * Add support for building X86-64 Linux wheels with OpenMP and SERIAL backends with Github Actions.
  [(#14)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/14)
 
- * Add the `kokkos_config` class variable, which stores the kokkos build and runtime information such as `Backend`, `Architecture`, `Kokkos Version`, `Compiler`, to LightningKokkos for users' query purpose. Users can also access other information such as `Options`, `Memory`, `Atomics` and `Vectorization` from `kokkos_config`.   
+ * Add the `kokkos_config` class variable, which stores the kokkos build and runtime information such as `Backend`, `Architecture`, `Kokkos Version`, `Compiler`, to LightningKokkos for users' query purpose. Users can also access other information such as `Options`, `Memory`, `Atomics` and `Vectorization` from `kokkos_config`.
  The workflow for build and runtime information query is:
+
  ```python
  >>> import pennylane as qml
  >>> dev = qml.device('lightning.kokkos', wires=3)
  >>> dev.kokkos_config["Backend"]
  {'Parallel': 'OpenMP'}
  ```
+
  [(#14)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/14)
 
 ### Breaking changes
 
 ### Improvements
+
+* Template n-qbit gate methods.
+[(#40)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/40)
 
 * Update `inv()` methods in Python unit tests with `qml.adjoint()`.
 [(#33)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/33)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Improvements
 
-* Template n-qbit gate methods.
+* Template n-qubit gate methods.
 [(#40)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/40)
 
 * Update `inv()` methods in Python unit tests with `qml.adjoint()`.

--- a/pennylane_lightning_kokkos/src/simulator/GateFunctors.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/GateFunctors.hpp
@@ -13,8 +13,7 @@ namespace KE = Kokkos::Experimental;
 namespace Pennylane {
 namespace Functors {
 
-template <class Precision, bool inverse = false>
-struct applySingleQubitOpFunctor {
+template <class Precision, bool inverse = false> struct singleQubitOpFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
     Kokkos::View<Kokkos::complex<Precision> *> matrix;
@@ -24,7 +23,7 @@ struct applySingleQubitOpFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applySingleQubitOpFunctor(
+    singleQubitOpFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits,
         const Kokkos::View<Kokkos::complex<Precision> *> &matrix_,
@@ -76,7 +75,7 @@ struct applySingleQubitOpFunctor {
  * @param wires Wires the gate applies to.
  * @param inverse Indicate whether inverse should be taken.
  */
-template <class Precision, bool inverse = false> struct applyTwoQubitOpFunctor {
+template <class Precision, bool inverse = false> struct twoQubitOpFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
     Kokkos::View<Kokkos::complex<Precision> *> matrix;
@@ -91,11 +90,10 @@ template <class Precision, bool inverse = false> struct applyTwoQubitOpFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyTwoQubitOpFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits,
-        const Kokkos::View<Kokkos::complex<Precision> *> &matrix_,
-        const std::vector<size_t> &wires) {
+    twoQubitOpFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                      std::size_t num_qubits,
+                      const Kokkos::View<Kokkos::complex<Precision> *> &matrix_,
+                      const std::vector<size_t> &wires) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -195,8 +193,7 @@ template <class Precision, bool inverse = false> struct applyTwoQubitOpFunctor {
     }
 };
 
-template <class Precision, bool inverse = false>
-struct applyMultiQubitOpFunctor {
+template <class Precision, bool inverse = false> struct multiQubitOpFunctor {
 
     using KokkosComplexVector = Kokkos::View<Kokkos::complex<Precision> *>;
     using KokkosIntVector = Kokkos::View<std::size_t *>;
@@ -209,9 +206,9 @@ struct applyMultiQubitOpFunctor {
     std::size_t dim;
     std::size_t num_qubits;
 
-    applyMultiQubitOpFunctor(KokkosComplexVector &arr_, std::size_t num_qubits_,
-                             const KokkosComplexVector &matrix_,
-                             KokkosIntVector &wires_) {
+    multiQubitOpFunctor(KokkosComplexVector &arr_, std::size_t num_qubits_,
+                        const KokkosComplexVector &matrix_,
+                        KokkosIntVector &wires_) {
         dim = 1U << wires_.size();
         indices = KokkosIntVector("indices", dim);
         coeffs_in = KokkosComplexVector("coeffs_in", dim);
@@ -283,7 +280,7 @@ struct applyMultiQubitOpFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyHadamardFunctor {
+template <class Precision, bool inverse = false> struct hadamardFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -292,10 +289,9 @@ template <class Precision, bool inverse = false> struct applyHadamardFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyHadamardFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        [[maybe_unused]] const std::vector<Precision> &params) {
+    hadamardFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                    std::size_t num_qubits, const std::vector<size_t> &wires,
+                    [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -331,7 +327,7 @@ template <class Precision, bool inverse = false> struct applyHadamardFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyPauliXFunctor {
+template <class Precision, bool inverse = false> struct pauliXFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -340,9 +336,9 @@ template <class Precision, bool inverse = false> struct applyPauliXFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyPauliXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits, const std::vector<size_t> &wires,
-                       [[maybe_unused]] const std::vector<Precision> &params) {
+    pauliXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                  std::size_t num_qubits, const std::vector<size_t> &wires,
+                  [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -359,7 +355,7 @@ template <class Precision, bool inverse = false> struct applyPauliXFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyPauliYFunctor {
+template <class Precision, bool inverse = false> struct pauliYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -368,9 +364,9 @@ template <class Precision, bool inverse = false> struct applyPauliYFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyPauliYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits, const std::vector<size_t> &wires,
-                       [[maybe_unused]] const std::vector<Precision> &params) {
+    pauliYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                  std::size_t num_qubits, const std::vector<size_t> &wires,
+                  [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -390,7 +386,7 @@ template <class Precision, bool inverse = false> struct applyPauliYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyPauliZFunctor {
+template <class Precision, bool inverse = false> struct pauliZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -399,9 +395,9 @@ template <class Precision, bool inverse = false> struct applyPauliZFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyPauliZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits, const std::vector<size_t> &wires,
-                       [[maybe_unused]] const std::vector<Precision> &params) {
+    pauliZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                  std::size_t num_qubits, const std::vector<size_t> &wires,
+                  [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -418,7 +414,7 @@ template <class Precision, bool inverse = false> struct applyPauliZFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applySFunctor {
+template <class Precision, bool inverse = false> struct sFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -428,9 +424,9 @@ template <class Precision, bool inverse = false> struct applySFunctor {
     std::size_t wire_parity_inv;
     Kokkos::complex<Precision> shift;
 
-    applySFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                  std::size_t num_qubits, const std::vector<size_t> &wires,
-                  [[maybe_unused]] const std::vector<Precision> &params) {
+    sFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+             std::size_t num_qubits, const std::vector<size_t> &wires,
+             [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -448,7 +444,7 @@ template <class Precision, bool inverse = false> struct applySFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyTFunctor {
+template <class Precision, bool inverse = false> struct tFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -458,9 +454,9 @@ template <class Precision, bool inverse = false> struct applyTFunctor {
     std::size_t wire_parity_inv;
     Kokkos::complex<Precision> shift;
 
-    applyTFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                  std::size_t num_qubits, const std::vector<size_t> &wires,
-                  [[maybe_unused]] const std::vector<Precision> &params) {
+    tFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+             std::size_t num_qubits, const std::vector<size_t> &wires,
+             [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -481,7 +477,7 @@ template <class Precision, bool inverse = false> struct applyTFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyPhaseShiftFunctor {
+template <class Precision, bool inverse = false> struct phaseShiftFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -491,10 +487,9 @@ template <class Precision, bool inverse = false> struct applyPhaseShiftFunctor {
     std::size_t wire_parity_inv;
     Kokkos::complex<Precision> s;
 
-    applyPhaseShiftFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                           std::size_t num_qubits,
-                           const std::vector<size_t> &wires,
-                           const std::vector<Precision> &params) {
+    phaseShiftFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                      std::size_t num_qubits, const std::vector<size_t> &wires,
+                      const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -515,7 +510,7 @@ template <class Precision, bool inverse = false> struct applyPhaseShiftFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyRXFunctor {
+template <class Precision, bool inverse = false> struct rxFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -525,9 +520,9 @@ template <class Precision, bool inverse = false> struct applyRXFunctor {
     std::size_t wire_parity_inv;
     Precision c;
     Precision s;
-    applyRXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires,
-                   const std::vector<Precision> &params) {
+    rxFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+              std::size_t num_qubits, const std::vector<size_t> &wires,
+              const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -554,7 +549,7 @@ template <class Precision, bool inverse = false> struct applyRXFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyRYFunctor {
+template <class Precision, bool inverse = false> struct ryFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -564,9 +559,9 @@ template <class Precision, bool inverse = false> struct applyRYFunctor {
     std::size_t wire_parity_inv;
     Precision c;
     Precision s;
-    applyRYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires,
-                   const std::vector<Precision> &params) {
+    ryFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+              std::size_t num_qubits, const std::vector<size_t> &wires,
+              const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -593,7 +588,7 @@ template <class Precision, bool inverse = false> struct applyRYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyRZFunctor {
+template <class Precision, bool inverse = false> struct rzFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -604,9 +599,9 @@ template <class Precision, bool inverse = false> struct applyRZFunctor {
     Kokkos::complex<Precision> shift_0;
     Kokkos::complex<Precision> shift_1;
 
-    applyRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires,
-                   const std::vector<Precision> &params) {
+    rzFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+              std::size_t num_qubits, const std::vector<size_t> &wires,
+              const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -631,7 +626,7 @@ template <class Precision, bool inverse = false> struct applyRZFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCNOTFunctor {
+template <class Precision, bool inverse = false> struct cnotFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -645,9 +640,9 @@ template <class Precision, bool inverse = false> struct applyCNOTFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyCNOTFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                     std::size_t num_qubits, const std::vector<size_t> &wires,
-                     [[maybe_unused]] const std::vector<Precision> &params) {
+    cnotFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                std::size_t num_qubits, const std::vector<size_t> &wires,
+                [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -676,7 +671,7 @@ template <class Precision, bool inverse = false> struct applyCNOTFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCYFunctor {
+template <class Precision, bool inverse = false> struct cyFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -690,9 +685,9 @@ template <class Precision, bool inverse = false> struct applyCYFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyCYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires,
-                   [[maybe_unused]] const std::vector<Precision> &params) {
+    cyFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+              std::size_t num_qubits, const std::vector<size_t> &wires,
+              [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -722,7 +717,7 @@ template <class Precision, bool inverse = false> struct applyCYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCZFunctor {
+template <class Precision, bool inverse = false> struct czFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -736,9 +731,9 @@ template <class Precision, bool inverse = false> struct applyCZFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyCZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires,
-                   [[maybe_unused]] const std::vector<Precision> &params) {
+    czFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+              std::size_t num_qubits, const std::vector<size_t> &wires,
+              [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -764,7 +759,7 @@ template <class Precision, bool inverse = false> struct applyCZFunctor {
         arr[i11] *= -1;
     }
 };
-template <class Precision, bool inverse = false> struct applyCRotFunctor {
+template <class Precision, bool inverse = false> struct cRotFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -783,9 +778,9 @@ template <class Precision, bool inverse = false> struct applyCRotFunctor {
     Kokkos::complex<Precision> rot_mat_0b01;
     Kokkos::complex<Precision> rot_mat_0b11;
 
-    applyCRotFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                     std::size_t num_qubits, const std::vector<size_t> &wires,
-                     const std::vector<Precision> &params) {
+    cRotFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                std::size_t num_qubits, const std::vector<size_t> &wires,
+                const std::vector<Precision> &params) {
 
         const Precision phi = (inverse) ? -params[2] : params[0];
         const Precision theta = (inverse) ? -params[1] : params[1];
@@ -833,7 +828,7 @@ template <class Precision, bool inverse = false> struct applyCRotFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applySWAPFunctor {
+template <class Precision, bool inverse = false> struct swapFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -847,9 +842,9 @@ template <class Precision, bool inverse = false> struct applySWAPFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applySWAPFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                     std::size_t num_qubits, const std::vector<size_t> &wires,
-                     [[maybe_unused]] const std::vector<Precision> &params) {
+    swapFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                std::size_t num_qubits, const std::vector<size_t> &wires,
+                [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -877,7 +872,7 @@ template <class Precision, bool inverse = false> struct applySWAPFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyIsingXXFunctor {
+template <class Precision, bool inverse = false> struct isingXXFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -894,10 +889,9 @@ template <class Precision, bool inverse = false> struct applyIsingXXFunctor {
     Precision cr;
     Precision sj;
 
-    applyIsingXXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        const std::vector<Precision> &params) {
+    isingXXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -944,7 +938,7 @@ template <class Precision, bool inverse = false> struct applyIsingXXFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyIsingXYFunctor {
+template <class Precision, bool inverse = false> struct isingXYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -961,10 +955,9 @@ template <class Precision, bool inverse = false> struct applyIsingXYFunctor {
     Precision cr;
     Precision sj;
 
-    applyIsingXYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        const std::vector<Precision> &params) {
+    isingXYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -1009,7 +1002,7 @@ template <class Precision, bool inverse = false> struct applyIsingXYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyIsingYYFunctor {
+template <class Precision, bool inverse = false> struct isingYYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1026,10 +1019,9 @@ template <class Precision, bool inverse = false> struct applyIsingYYFunctor {
     Precision cr;
     Precision sj;
 
-    applyIsingYYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        const std::vector<Precision> &params) {
+    isingYYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   const std::vector<Precision> &params) {
         const Precision &angle = params[0];
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
@@ -1075,7 +1067,7 @@ template <class Precision, bool inverse = false> struct applyIsingYYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyIsingZZFunctor {
+template <class Precision, bool inverse = false> struct isingZZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1094,10 +1086,9 @@ template <class Precision, bool inverse = false> struct applyIsingZZFunctor {
     Kokkos::complex<Precision> shift_0;
     Kokkos::complex<Precision> shift_1;
 
-    applyIsingZZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        const std::vector<Precision> &params) {
+    isingZZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   const std::vector<Precision> &params) {
         const Precision &angle = params[0];
 
         rev_wire0 = num_qubits - wires[1] - 1;
@@ -1140,7 +1131,7 @@ template <class Precision, bool inverse = false> struct applyIsingZZFunctor {
     }
 };
 template <class Precision, bool inverse = false>
-struct applySingleExcitationFunctor {
+struct singleExcitationFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1157,10 +1148,10 @@ struct applySingleExcitationFunctor {
     Precision cr;
     Precision sj;
 
-    applySingleExcitationFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        const std::vector<Precision> &params) {
+    singleExcitationFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                            std::size_t num_qubits,
+                            const std::vector<size_t> &wires,
+                            const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -1199,7 +1190,7 @@ struct applySingleExcitationFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applySingleExcitationMinusFunctor {
+struct singleExcitationMinusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1217,7 +1208,7 @@ struct applySingleExcitationMinusFunctor {
     Precision sj;
     Kokkos::complex<Precision> e;
 
-    applySingleExcitationMinusFunctor(
+    singleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         const std::vector<Precision> &params) {
@@ -1264,7 +1255,7 @@ struct applySingleExcitationMinusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applySingleExcitationPlusFunctor {
+struct singleExcitationPlusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1282,7 +1273,7 @@ struct applySingleExcitationPlusFunctor {
     Precision sj;
     Kokkos::complex<Precision> e;
 
-    applySingleExcitationPlusFunctor(
+    singleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         const std::vector<Precision> &params) {
@@ -1329,7 +1320,7 @@ struct applySingleExcitationPlusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyDoubleExcitationFunctor {
+struct doubleExcitationFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1359,10 +1350,10 @@ struct applyDoubleExcitationFunctor {
     Precision cr;
     Precision sj;
 
-    applyDoubleExcitationFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        const std::vector<Precision> &params) {
+    doubleExcitationFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                            std::size_t num_qubits,
+                            const std::vector<size_t> &wires,
+                            const std::vector<Precision> &params) {
 
         const Precision &angle = params[0];
         rev_wire0 = num_qubits - wires[3] - 1;
@@ -1448,7 +1439,7 @@ struct applyDoubleExcitationFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyDoubleExcitationMinusFunctor {
+struct doubleExcitationMinusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1479,7 +1470,7 @@ struct applyDoubleExcitationMinusFunctor {
     Precision sj;
     Kokkos::complex<Precision> e;
 
-    applyDoubleExcitationMinusFunctor(
+    doubleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         const std::vector<Precision> &params) {
@@ -1601,7 +1592,7 @@ struct applyDoubleExcitationMinusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyDoubleExcitationPlusFunctor {
+struct doubleExcitationPlusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1632,7 +1623,7 @@ struct applyDoubleExcitationPlusFunctor {
     Precision sj;
     Kokkos::complex<Precision> e;
 
-    applyDoubleExcitationPlusFunctor(
+    doubleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         const std::vector<Precision> &params) {
@@ -1755,7 +1746,7 @@ struct applyDoubleExcitationPlusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyControlledPhaseShiftFunctor {
+struct controlledPhaseShiftFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1771,7 +1762,7 @@ struct applyControlledPhaseShiftFunctor {
 
     Kokkos::complex<Precision> s;
 
-    applyControlledPhaseShiftFunctor(
+    controlledPhaseShiftFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         const std::vector<Precision> &params) {
@@ -1806,7 +1797,7 @@ struct applyControlledPhaseShiftFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCRXFunctor {
+template <class Precision, bool inverse = false> struct crxFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1823,9 +1814,9 @@ template <class Precision, bool inverse = false> struct applyCRXFunctor {
     Precision c;
     Precision js;
 
-    applyCRXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                    std::size_t num_qubits, const std::vector<size_t> &wires,
-                    const std::vector<Precision> &params) {
+    crxFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+               std::size_t num_qubits, const std::vector<size_t> &wires,
+               const std::vector<Precision> &params) {
         const Precision &angle = params[0];
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
@@ -1866,7 +1857,7 @@ template <class Precision, bool inverse = false> struct applyCRXFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCRYFunctor {
+template <class Precision, bool inverse = false> struct cryFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1883,9 +1874,9 @@ template <class Precision, bool inverse = false> struct applyCRYFunctor {
     Precision c;
     Precision s;
 
-    applyCRYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                    std::size_t num_qubits, const std::vector<size_t> &wires,
-                    const std::vector<Precision> &params) {
+    cryFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+               std::size_t num_qubits, const std::vector<size_t> &wires,
+               const std::vector<Precision> &params) {
         const Precision &angle = params[0];
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
@@ -1922,7 +1913,7 @@ template <class Precision, bool inverse = false> struct applyCRYFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCRZFunctor {
+template <class Precision, bool inverse = false> struct crzFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -1939,9 +1930,9 @@ template <class Precision, bool inverse = false> struct applyCRZFunctor {
     Kokkos::complex<Precision> shifts_0;
     Kokkos::complex<Precision> shifts_1;
 
-    applyCRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                    std::size_t num_qubits, const std::vector<size_t> &wires,
-                    const std::vector<Precision> &params) {
+    crzFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+               std::size_t num_qubits, const std::vector<size_t> &wires,
+               const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -1981,7 +1972,7 @@ template <class Precision, bool inverse = false> struct applyCRZFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyCSWAPFunctor {
+template <class Precision, bool inverse = false> struct cSWAPFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2003,9 +1994,9 @@ template <class Precision, bool inverse = false> struct applyCSWAPFunctor {
     Kokkos::complex<Precision> shifts_1;
     Kokkos::complex<Precision> shifts_2;
 
-    applyCSWAPFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                      std::size_t num_qubits, const std::vector<size_t> &wires,
-                      [[maybe_unused]] const std::vector<Precision> &params) {
+    cSWAPFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                 std::size_t num_qubits, const std::vector<size_t> &wires,
+                 [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[2] - 1;
         rev_wire1 = num_qubits - wires[1] - 1;
         rev_wire2 = num_qubits - wires[0] - 1; // Control qubit
@@ -2049,7 +2040,7 @@ template <class Precision, bool inverse = false> struct applyCSWAPFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyToffoliFunctor {
+template <class Precision, bool inverse = false> struct toffoliFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2071,10 +2062,9 @@ template <class Precision, bool inverse = false> struct applyToffoliFunctor {
     Kokkos::complex<Precision> shifts_1;
     Kokkos::complex<Precision> shifts_2;
 
-    applyToffoliFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        [[maybe_unused]] const std::vector<Precision> &params) {
+    toffoliFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[2] - 1;
         rev_wire1 = num_qubits - wires[1] - 1;
         rev_wire2 = num_qubits - wires[0] - 1; // Control qubit
@@ -2119,7 +2109,7 @@ template <class Precision, bool inverse = false> struct applyToffoliFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyMultiRZFunctor {
+template <class Precision, bool inverse = false> struct multiRZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2128,10 +2118,9 @@ template <class Precision, bool inverse = false> struct applyMultiRZFunctor {
     Kokkos::complex<Precision> shift_0;
     Kokkos::complex<Precision> shift_1;
 
-    applyMultiRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                        std::size_t num_qubits,
-                        const std::vector<size_t> &wires,
-                        const std::vector<Precision> &params) {
+    multiRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   const std::vector<Precision> &params) {
 
         const Precision &angle = params[0];
         const Kokkos::complex<Precision> first = Kokkos::complex<Precision>{
@@ -2160,8 +2149,7 @@ template <class Precision, bool inverse = false> struct applyMultiRZFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorPhaseShiftFunctor {
+template <class Precision, bool adj = false> struct generatorPhaseShiftFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2170,7 +2158,7 @@ struct applyGeneratorPhaseShiftFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyGeneratorPhaseShiftFunctor(
+    generatorPhaseShiftFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2189,8 +2177,7 @@ struct applyGeneratorPhaseShiftFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorIsingXXFunctor {
+template <class Precision, bool adj = false> struct generatorIsingXXFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2204,7 +2191,7 @@ struct applyGeneratorIsingXXFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorIsingXXFunctor(
+    generatorIsingXXFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2238,8 +2225,7 @@ struct applyGeneratorIsingXXFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorIsingXYFunctor {
+template <class Precision, bool adj = false> struct generatorIsingXYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2253,7 +2239,7 @@ struct applyGeneratorIsingXYFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorIsingXYFunctor(
+    generatorIsingXYFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2288,8 +2274,7 @@ struct applyGeneratorIsingXYFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorIsingYYFunctor {
+template <class Precision, bool adj = false> struct generatorIsingYYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2303,7 +2288,7 @@ struct applyGeneratorIsingYYFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorIsingYYFunctor(
+    generatorIsingYYFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2339,8 +2324,7 @@ struct applyGeneratorIsingYYFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorIsingZZFunctor {
+template <class Precision, bool adj = false> struct generatorIsingZZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2354,7 +2338,7 @@ struct applyGeneratorIsingZZFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorIsingZZFunctor(
+    generatorIsingZZFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2387,7 +2371,7 @@ struct applyGeneratorIsingZZFunctor {
 };
 
 template <class Precision, bool adj = false>
-struct applyGeneratorSingleExcitationFunctor {
+struct generatorSingleExcitationFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2401,7 +2385,7 @@ struct applyGeneratorSingleExcitationFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorSingleExcitationFunctor(
+    generatorSingleExcitationFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2440,7 +2424,7 @@ struct applyGeneratorSingleExcitationFunctor {
 };
 
 template <class Precision, bool adj = false>
-struct applyGeneratorSingleExcitationMinusFunctor {
+struct generatorSingleExcitationMinusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2454,7 +2438,7 @@ struct applyGeneratorSingleExcitationMinusFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorSingleExcitationMinusFunctor(
+    generatorSingleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2490,7 +2474,7 @@ struct applyGeneratorSingleExcitationMinusFunctor {
 };
 
 template <class Precision, bool adj = false>
-struct applyGeneratorSingleExcitationPlusFunctor {
+struct generatorSingleExcitationPlusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2504,7 +2488,7 @@ struct applyGeneratorSingleExcitationPlusFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorSingleExcitationPlusFunctor(
+    generatorSingleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2544,7 +2528,7 @@ struct applyGeneratorSingleExcitationPlusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyGeneratorDoubleExcitationFunctor {
+struct generatorDoubleExcitationFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2571,7 +2555,7 @@ struct applyGeneratorDoubleExcitationFunctor {
     Kokkos::complex<Precision> shifts_2;
     Kokkos::complex<Precision> shifts_3;
 
-    applyGeneratorDoubleExcitationFunctor(
+    generatorDoubleExcitationFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2687,7 +2671,7 @@ struct applyGeneratorDoubleExcitationFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyGeneratorDoubleExcitationMinusFunctor {
+struct generatorDoubleExcitationMinusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2714,7 +2698,7 @@ struct applyGeneratorDoubleExcitationMinusFunctor {
     Kokkos::complex<Precision> shifts_2;
     Kokkos::complex<Precision> shifts_3;
 
-    applyGeneratorDoubleExcitationMinusFunctor(
+    generatorDoubleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2797,7 +2781,7 @@ struct applyGeneratorDoubleExcitationMinusFunctor {
 };
 
 template <class Precision, bool inverse = false>
-struct applyGeneratorDoubleExcitationPlusFunctor {
+struct generatorDoubleExcitationPlusFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2824,7 +2808,7 @@ struct applyGeneratorDoubleExcitationPlusFunctor {
     Kokkos::complex<Precision> shifts_2;
     Kokkos::complex<Precision> shifts_3;
 
-    applyGeneratorDoubleExcitationPlusFunctor(
+    generatorDoubleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2907,7 +2891,7 @@ struct applyGeneratorDoubleExcitationPlusFunctor {
 };
 
 template <class Precision, bool adj = false>
-struct applyGeneratorControlledPhaseShiftFunctor {
+struct generatorControlledPhaseShiftFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2921,7 +2905,7 @@ struct applyGeneratorControlledPhaseShiftFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorControlledPhaseShiftFunctor(
+    generatorControlledPhaseShiftFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
         std::size_t num_qubits, const std::vector<size_t> &wires,
         [[maybe_unused]] const std::vector<Precision> &params) {
@@ -2954,7 +2938,7 @@ struct applyGeneratorControlledPhaseShiftFunctor {
     }
 };
 
-template <class Precision, bool adj = false> struct applyGeneratorCRXFunctor {
+template <class Precision, bool adj = false> struct generatorCRXFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -2968,10 +2952,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRXFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRXFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        [[maybe_unused]] const std::vector<Precision> &params) {
+    generatorCRXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                        std::size_t num_qubits,
+                        const std::vector<size_t> &wires,
+                        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -3002,7 +2986,7 @@ template <class Precision, bool adj = false> struct applyGeneratorCRXFunctor {
     }
 };
 
-template <class Precision, bool adj = false> struct applyGeneratorCRYFunctor {
+template <class Precision, bool adj = false> struct generatorCRYFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -3016,10 +3000,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRYFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRYFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        [[maybe_unused]] const std::vector<Precision> &params) {
+    generatorCRYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                        std::size_t num_qubits,
+                        const std::vector<size_t> &wires,
+                        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -3055,7 +3039,7 @@ template <class Precision, bool adj = false> struct applyGeneratorCRYFunctor {
     }
 };
 
-template <class Precision, bool adj = false> struct applyGeneratorCRZFunctor {
+template <class Precision, bool adj = false> struct generatorCRZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -3069,10 +3053,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRZFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRZFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires,
-        [[maybe_unused]] const std::vector<Precision> &params) {
+    generatorCRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                        std::size_t num_qubits,
+                        const std::vector<size_t> &wires,
+                        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -3103,16 +3087,15 @@ template <class Precision, bool adj = false> struct applyGeneratorCRZFunctor {
     }
 };
 
-template <class Precision, bool adj = false>
-struct applyGeneratorMultiRZFunctor {
+template <class Precision, bool adj = false> struct generatorMultiRZFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
     std::size_t wires_parity;
 
-    applyGeneratorMultiRZFunctor(
-        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+    generatorMultiRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+                            std::size_t num_qubits,
+                            const std::vector<size_t> &wires) {
         arr = arr_;
         wires_parity = static_cast<size_t>(0U);
         for (size_t wire : wires) {
@@ -3128,7 +3111,7 @@ struct applyGeneratorMultiRZFunctor {
     }
 };
 
-template <class Precision, bool inverse = false> struct applyRotFunctor {
+template <class Precision, bool inverse = false> struct rotFunctor {
 
     Kokkos::View<Kokkos::complex<Precision> *> arr;
 
@@ -3142,9 +3125,9 @@ template <class Precision, bool inverse = false> struct applyRotFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyRotFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                    std::size_t num_qubits, const std::vector<size_t> &wires,
-                    const std::vector<Precision> &params) {
+    rotFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+               std::size_t num_qubits, const std::vector<size_t> &wires,
+               const std::vector<Precision> &params) {
         const Precision phi = (inverse) ? -params[2] : params[0];
         const Precision theta = (inverse) ? -params[1] : params[1];
         const Precision omega = (inverse) ? -params[0] : params[2];

--- a/pennylane_lightning_kokkos/src/simulator/GateFunctors.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/GateFunctors.hpp
@@ -292,9 +292,10 @@ template <class Precision, bool inverse = false> struct applyHadamardFunctor {
     std::size_t wire_parity;
     std::size_t wire_parity_inv;
 
-    applyHadamardFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                         std::size_t num_qubits,
-                         const std::vector<size_t> &wires) {
+    applyHadamardFunctor(
+        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -340,8 +341,8 @@ template <class Precision, bool inverse = false> struct applyPauliXFunctor {
     std::size_t wire_parity_inv;
 
     applyPauliXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits,
-                       const std::vector<size_t> &wires) {
+                       std::size_t num_qubits, const std::vector<size_t> &wires,
+                       [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -368,8 +369,8 @@ template <class Precision, bool inverse = false> struct applyPauliYFunctor {
     std::size_t wire_parity_inv;
 
     applyPauliYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits,
-                       const std::vector<size_t> &wires) {
+                       std::size_t num_qubits, const std::vector<size_t> &wires,
+                       [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -399,8 +400,8 @@ template <class Precision, bool inverse = false> struct applyPauliZFunctor {
     std::size_t wire_parity_inv;
 
     applyPauliZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                       std::size_t num_qubits,
-                       const std::vector<size_t> &wires) {
+                       std::size_t num_qubits, const std::vector<size_t> &wires,
+                       [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -428,7 +429,8 @@ template <class Precision, bool inverse = false> struct applySFunctor {
     Kokkos::complex<Precision> shift;
 
     applySFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                  std::size_t num_qubits, const std::vector<size_t> &wires) {
+                  std::size_t num_qubits, const std::vector<size_t> &wires,
+                  [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -457,7 +459,8 @@ template <class Precision, bool inverse = false> struct applyTFunctor {
     Kokkos::complex<Precision> shift;
 
     applyTFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                  std::size_t num_qubits, const std::vector<size_t> &wires) {
+                  std::size_t num_qubits, const std::vector<size_t> &wires,
+                  [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -491,12 +494,13 @@ template <class Precision, bool inverse = false> struct applyPhaseShiftFunctor {
     applyPhaseShiftFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
                            std::size_t num_qubits,
                            const std::vector<size_t> &wires,
-                           const Precision &angle) {
+                           const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
+        const Precision &angle = params[0];
 
         s = inverse ? exp(-Kokkos::complex<Precision>(0, angle))
                     : exp(Kokkos::complex<Precision>(0, angle));
@@ -642,7 +646,8 @@ template <class Precision, bool inverse = false> struct applyCNOTFunctor {
     std::size_t parity_middle;
 
     applyCNOTFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                     std::size_t num_qubits, const std::vector<size_t> &wires) {
+                     std::size_t num_qubits, const std::vector<size_t> &wires,
+                     [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -686,7 +691,8 @@ template <class Precision, bool inverse = false> struct applyCYFunctor {
     std::size_t parity_middle;
 
     applyCYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires) {
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -731,7 +737,8 @@ template <class Precision, bool inverse = false> struct applyCZFunctor {
     std::size_t parity_middle;
 
     applyCZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                   std::size_t num_qubits, const std::vector<size_t> &wires) {
+                   std::size_t num_qubits, const std::vector<size_t> &wires,
+                   [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -841,7 +848,8 @@ template <class Precision, bool inverse = false> struct applySWAPFunctor {
     std::size_t parity_middle;
 
     applySWAPFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                     std::size_t num_qubits, const std::vector<size_t> &wires) {
+                     std::size_t num_qubits, const std::vector<size_t> &wires,
+                     [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -1996,8 +2004,8 @@ template <class Precision, bool inverse = false> struct applyCSWAPFunctor {
     Kokkos::complex<Precision> shifts_2;
 
     applyCSWAPFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                      std::size_t num_qubits,
-                      const std::vector<size_t> &wires) {
+                      std::size_t num_qubits, const std::vector<size_t> &wires,
+                      [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[2] - 1;
         rev_wire1 = num_qubits - wires[1] - 1;
         rev_wire2 = num_qubits - wires[0] - 1; // Control qubit
@@ -2065,7 +2073,8 @@ template <class Precision, bool inverse = false> struct applyToffoliFunctor {
 
     applyToffoliFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
                         std::size_t num_qubits,
-                        const std::vector<size_t> &wires) {
+                        const std::vector<size_t> &wires,
+                        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[2] - 1;
         rev_wire1 = num_qubits - wires[1] - 1;
         rev_wire2 = num_qubits - wires[0] - 1; // Control qubit
@@ -2163,7 +2172,8 @@ struct applyGeneratorPhaseShiftFunctor {
 
     applyGeneratorPhaseShiftFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
         rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
@@ -2196,7 +2206,8 @@ struct applyGeneratorIsingXXFunctor {
 
     applyGeneratorIsingXXFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2244,7 +2255,8 @@ struct applyGeneratorIsingXYFunctor {
 
     applyGeneratorIsingXYFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2293,7 +2305,8 @@ struct applyGeneratorIsingYYFunctor {
 
     applyGeneratorIsingYYFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2343,7 +2356,8 @@ struct applyGeneratorIsingZZFunctor {
 
     applyGeneratorIsingZZFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2389,7 +2403,8 @@ struct applyGeneratorSingleExcitationFunctor {
 
     applyGeneratorSingleExcitationFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2441,7 +2456,8 @@ struct applyGeneratorSingleExcitationMinusFunctor {
 
     applyGeneratorSingleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2490,7 +2506,8 @@ struct applyGeneratorSingleExcitationPlusFunctor {
 
     applyGeneratorSingleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2556,7 +2573,8 @@ struct applyGeneratorDoubleExcitationFunctor {
 
     applyGeneratorDoubleExcitationFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[3] - 1;
         rev_wire1 = num_qubits - wires[2] - 1;
         rev_wire2 = num_qubits - wires[1] - 1;
@@ -2698,7 +2716,8 @@ struct applyGeneratorDoubleExcitationMinusFunctor {
 
     applyGeneratorDoubleExcitationMinusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[3] - 1;
         rev_wire1 = num_qubits - wires[2] - 1;
         rev_wire2 = num_qubits - wires[1] - 1;
@@ -2807,7 +2826,8 @@ struct applyGeneratorDoubleExcitationPlusFunctor {
 
     applyGeneratorDoubleExcitationPlusFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[3] - 1;
         rev_wire1 = num_qubits - wires[2] - 1;
         rev_wire2 = num_qubits - wires[1] - 1;
@@ -2903,7 +2923,8 @@ struct applyGeneratorControlledPhaseShiftFunctor {
 
     applyGeneratorControlledPhaseShiftFunctor(
         Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-        std::size_t num_qubits, const std::vector<size_t> &wires) {
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2947,9 +2968,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRXFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRXFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                             std::size_t num_qubits,
-                             const std::vector<size_t> &wires) {
+    applyGeneratorCRXFunctor(
+        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -2994,9 +3016,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRYFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRYFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                             std::size_t num_qubits,
-                             const std::vector<size_t> &wires) {
+    applyGeneratorCRYFunctor(
+        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 
@@ -3046,9 +3069,10 @@ template <class Precision, bool adj = false> struct applyGeneratorCRZFunctor {
     std::size_t parity_high;
     std::size_t parity_middle;
 
-    applyGeneratorCRZFunctor(Kokkos::View<Kokkos::complex<Precision> *> &arr_,
-                             std::size_t num_qubits,
-                             const std::vector<size_t> &wires) {
+    applyGeneratorCRZFunctor(
+        Kokkos::View<Kokkos::complex<Precision> *> &arr_,
+        std::size_t num_qubits, const std::vector<size_t> &wires,
+        [[maybe_unused]] const std::vector<Precision> &params) {
         rev_wire0 = num_qubits - wires[1] - 1;
         rev_wire1 = num_qubits - wires[0] - 1; // Control qubit
 

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -905,27 +905,27 @@ template <class Precision> class StateVectorKokkos {
     /**
      * @brief Templated method that applies special n-qubit gates.
      *
-     * @tparam Gate functor class for Kokkos dispatcher.
-     * @tparam Number of qubits.
+     * @tparam functor_t Gate functor class for Kokkos dispatcher.
+     * @tparam nqubits Number of qubits.
      * @param wires Wires to apply gate to.
      * @param inverse Indicates whether to use adjoint of gate.
      * @param params parameters for this gate
      */
-    template <template <class, bool> class functor_t, int nqbits>
+    template <template <class, bool> class functor_t, int nqubits>
     void applyGateFunctor(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
         auto &&num_qubits = getNumQubits();
-        assert(wires.size() == nqbits);
+        assert(wires.size() == nqubits);
         if (!inverse) {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - nqbits)),
+                    0, Util::exp2(num_qubits - nqubits)),
                 functor_t<Precision, false>(*data_, num_qubits, wires, params));
         } else {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - nqbits)),
+                    0, Util::exp2(num_qubits - nqubits)),
                 functor_t<Precision, true>(*data_, num_qubits, wires, params));
         }
     }

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -684,12 +684,12 @@ template <class Precision> class StateVectorKokkos {
         if (!inverse) {
             Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
                                      0, Util::exp2(num_qubits - 1)),
-                                 applySingleQubitOpFunctor<Precision, false>(
+                                 singleQubitOpFunctor<Precision, false>(
                                      *data_, num_qubits, matrix, wires));
         } else {
             Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
                                      0, Util::exp2(num_qubits - 1)),
-                                 applySingleQubitOpFunctor<Precision, true>(
+                                 singleQubitOpFunctor<Precision, true>(
                                      *data_, num_qubits, matrix, wires));
         }
     }
@@ -709,12 +709,12 @@ template <class Precision> class StateVectorKokkos {
         if (!inverse) {
             Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
                                      0, Util::exp2(num_qubits - 2)),
-                                 applyTwoQubitOpFunctor<Precision, false>(
+                                 twoQubitOpFunctor<Precision, false>(
                                      *data_, num_qubits, matrix, wires));
         } else {
             Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
                                      0, Util::exp2(num_qubits - 2)),
-                                 applyTwoQubitOpFunctor<Precision, true>(
+                                 twoQubitOpFunctor<Precision, true>(
                                      *data_, num_qubits, matrix, wires));
         }
     }
@@ -747,14 +747,14 @@ template <class Precision> class StateVectorKokkos {
                 Kokkos::parallel_for(
                     Kokkos::RangePolicy<KokkosExecSpace>(
                         0, Util::exp2(num_qubits_ - wires.size())),
-                    applyMultiQubitOpFunctor<Precision, false>(
-                        *data_, num_qubits, matrix, wires_view));
+                    multiQubitOpFunctor<Precision, false>(*data_, num_qubits,
+                                                          matrix, wires_view));
             } else {
                 Kokkos::parallel_for(
                     Kokkos::RangePolicy<KokkosExecSpace>(
                         0, Util::exp2(num_qubits_ - wires.size())),
-                    applyMultiQubitOpFunctor<Precision, true>(
-                        *data_, num_qubits, matrix, wires_view));
+                    multiQubitOpFunctor<Precision, true>(*data_, num_qubits,
+                                                         matrix, wires_view));
             }
         }
     }
@@ -903,7 +903,7 @@ template <class Precision> class StateVectorKokkos {
     }
 
     /**
-     * @brief Templated method that applies special n-qbit gates.
+     * @brief Templated method that applies special n-qubit gates.
      *
      * @tparam Gate functor class for Kokkos dispatcher.
      * @tparam Number of qubits.
@@ -940,7 +940,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliX(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyPauliXFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<pauliXFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -953,7 +953,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliY(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyPauliYFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<pauliYFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -967,7 +967,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliZ(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyPauliZFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<pauliZFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1251,7 +1251,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyHadamard(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyHadamardFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<hadamardFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1263,7 +1263,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyS(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applySFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<sFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1275,7 +1275,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyT(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyTFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<tFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1287,7 +1287,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRX(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<applyRXFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<rxFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1299,7 +1299,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRY(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<applyRYFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<ryFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1311,7 +1311,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyRZFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<rzFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1324,8 +1324,7 @@ template <class Precision> class StateVectorKokkos {
     void applyPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyPhaseShiftFunctor, 1>(wires, inverse,
-                                                         params);
+        applySpecialQubitGate<phaseShiftFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1337,7 +1336,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRot(const std::vector<size_t> &wires, bool inverse,
                   const std::vector<Precision> &params) {
-        applySpecialQubitGate<applyRotFunctor, 1>(wires, inverse, params);
+        applySpecialQubitGate<rotFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1349,7 +1348,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCYFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<cyFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1361,7 +1360,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCZFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<czFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1373,7 +1372,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCNOT(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCNOTFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<cnotFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1385,7 +1384,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applySWAP(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applySWAPFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<swapFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1399,8 +1398,8 @@ template <class Precision> class StateVectorKokkos {
     void applyControlledPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyControlledPhaseShiftFunctor, 2>(
-            wires, inverse, params);
+        applySpecialQubitGate<controlledPhaseShiftFunctor, 2>(wires, inverse,
+                                                              params);
     }
 
     /**
@@ -1412,7 +1411,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRX(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCRXFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<crxFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1424,7 +1423,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRY(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCRYFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<cryFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1436,7 +1435,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRZ(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCRZFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<crzFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1448,7 +1447,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRot(const std::vector<size_t> &wires, bool inverse,
                    [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<applyCRotFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<cRotFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1461,7 +1460,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXX(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyIsingXXFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<isingXXFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1474,7 +1473,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyIsingXYFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<isingXYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1487,7 +1486,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingYY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyIsingYYFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<isingYYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1500,7 +1499,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingZZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyIsingZZFunctor, 2>(wires, inverse, params);
+        applySpecialQubitGate<isingZZFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1514,8 +1513,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applySingleExcitationFunctor, 2>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<singleExcitationFunctor, 2>(wires, inverse,
+                                                          params);
     }
 
     /**
@@ -1529,8 +1528,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applySingleExcitationMinusFunctor, 2>(
-            wires, inverse, params);
+        applySpecialQubitGate<singleExcitationMinusFunctor, 2>(wires, inverse,
+                                                               params);
     }
 
     /**
@@ -1544,8 +1543,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applySingleExcitationPlusFunctor, 2>(
-            wires, inverse, params);
+        applySpecialQubitGate<singleExcitationPlusFunctor, 2>(wires, inverse,
+                                                              params);
     }
 
     /**
@@ -1559,8 +1558,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyDoubleExcitationFunctor, 4>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<doubleExcitationFunctor, 4>(wires, inverse,
+                                                          params);
     }
 
     /**
@@ -1574,8 +1573,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyDoubleExcitationMinusFunctor, 4>(
-            wires, inverse, params);
+        applySpecialQubitGate<doubleExcitationMinusFunctor, 4>(wires, inverse,
+                                                               params);
     }
 
     /**
@@ -1589,8 +1588,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyDoubleExcitationPlusFunctor, 4>(
-            wires, inverse, params);
+        applySpecialQubitGate<doubleExcitationPlusFunctor, 4>(wires, inverse,
+                                                              params);
     }
 
     /**
@@ -1608,13 +1607,13 @@ template <class Precision> class StateVectorKokkos {
         if (!inverse) {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(0, Util::exp2(num_qubits)),
-                applyMultiRZFunctor<Precision, false>(*data_, num_qubits, wires,
-                                                      params));
+                multiRZFunctor<Precision, false>(*data_, num_qubits, wires,
+                                                 params));
         } else {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(0, Util::exp2(num_qubits)),
-                applyMultiRZFunctor<Precision, true>(*data_, num_qubits, wires,
-                                                     params));
+                multiRZFunctor<Precision, true>(*data_, num_qubits, wires,
+                                                params));
         }
     }
 
@@ -1628,7 +1627,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyCSWAP(const std::vector<size_t> &wires, bool inverse = false,
                [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyCSWAPFunctor, 3>(wires, inverse, params);
+        applySpecialQubitGate<cSWAPFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -1641,7 +1640,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyToffoli(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<applyToffoliFunctor, 3>(wires, inverse, params);
+        applySpecialQubitGate<toffoliFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -1655,8 +1654,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorPhaseShiftFunctor, 1>(
-            wires, inverse, params);
+        applySpecialQubitGate<generatorPhaseShiftFunctor, 1>(wires, inverse,
+                                                             params);
         return static_cast<Precision>(1.0);
     }
 
@@ -1671,8 +1670,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorIsingXXFunctor, 2>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<generatorIsingXXFunctor, 2>(wires, inverse,
+                                                          params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1687,8 +1686,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorIsingXYFunctor, 2>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<generatorIsingXYFunctor, 2>(wires, inverse,
+                                                          params);
         return static_cast<Precision>(0.5);
     }
 
@@ -1703,8 +1702,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorIsingYYFunctor, 2>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<generatorIsingYYFunctor, 2>(wires, inverse,
+                                                          params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1719,8 +1718,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorIsingZZFunctor, 2>(wires, inverse,
-                                                               params);
+        applySpecialQubitGate<generatorIsingZZFunctor, 2>(wires, inverse,
+                                                          params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1736,7 +1735,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorSingleExcitationFunctor, 2>(
+        applySpecialQubitGate<generatorSingleExcitationFunctor, 2>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1753,7 +1752,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorSingleExcitationMinusFunctor, 2>(
+        applySpecialQubitGate<generatorSingleExcitationMinusFunctor, 2>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1770,7 +1769,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorSingleExcitationPlusFunctor, 2>(
+        applySpecialQubitGate<generatorSingleExcitationPlusFunctor, 2>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1787,7 +1786,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorDoubleExcitationFunctor, 4>(
+        applySpecialQubitGate<generatorDoubleExcitationFunctor, 4>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1804,7 +1803,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorDoubleExcitationMinusFunctor, 4>(
+        applySpecialQubitGate<generatorDoubleExcitationMinusFunctor, 4>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1821,7 +1820,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorDoubleExcitationPlusFunctor, 4>(
+        applySpecialQubitGate<generatorDoubleExcitationPlusFunctor, 4>(
             wires, inverse, params);
         return static_cast<Precision>(0.5);
     }
@@ -1883,7 +1882,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorControlledPhaseShiftFunctor, 2>(
+        applySpecialQubitGate<generatorControlledPhaseShiftFunctor, 2>(
             wires, inverse, params);
         return static_cast<Precision>(1);
     }
@@ -1900,8 +1899,7 @@ template <class Precision> class StateVectorKokkos {
         [[maybe_unused]] const std::vector<Precision> &params = {})
 
         -> Precision {
-        applySpecialQubitGate<applyGeneratorCRXFunctor, 2>(wires, inverse,
-                                                           params);
+        applySpecialQubitGate<generatorCRXFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1916,8 +1914,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorCRYFunctor, 2>(wires, inverse,
-                                                           params);
+        applySpecialQubitGate<generatorCRYFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1932,8 +1929,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<applyGeneratorCRZFunctor, 2>(wires, inverse,
-                                                           params);
+        applySpecialQubitGate<generatorCRZFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1953,13 +1949,13 @@ template <class Precision> class StateVectorKokkos {
         if (inverse == false) {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(0, Util::exp2(num_qubits)),
-                applyGeneratorMultiRZFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
+                generatorMultiRZFunctor<Precision, false>(*data_, num_qubits,
+                                                          wires));
         } else {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(0, Util::exp2(num_qubits)),
-                applyGeneratorMultiRZFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
+                generatorMultiRZFunctor<Precision, true>(*data_, num_qubits,
+                                                         wires));
         }
         return -static_cast<Precision>(0.5);
     }

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -905,6 +905,8 @@ template <class Precision> class StateVectorKokkos {
     /**
      * @brief Templated method that applies special n-qbit gates.
      *
+     * @tparam Gate functor class for Kokkos dispatcher.
+     * @tparam Number of qubits.
      * @param wires Wires to apply gate to.
      * @param inverse Indicates whether to use adjoint of gate.
      * @param params parameters for this gate

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -78,328 +78,360 @@ template <class Precision> class StateVectorKokkos {
 
     StateVectorKokkos() = delete;
     StateVectorKokkos(size_t num_qubits, const Kokkos::InitArguments &kokkos_args = {})
-        : gates_{
-                //Identity
-                 {"PauliX", 
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyPauliX(std::forward<decltype(wires)>(wires),
-                                  std::forward<decltype(adjoint)>(adjoint),
-                                  std::forward<decltype(params)>(params));
-                  }},
-                 {"PauliY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyPauliY(std::forward<decltype(wires)>(wires),
-                                  std::forward<decltype(adjoint)>(adjoint),
-                                  std::forward<decltype(params)>(params));
-                  }},
-                 {"PauliZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyPauliZ(std::forward<decltype(wires)>(wires),
-                                  std::forward<decltype(adjoint)>(adjoint),
-                                  std::forward<decltype(params)>(params));
-                  }},
-                 {"Hadamard",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyHadamard(std::forward<decltype(wires)>(wires),
+            : gates_{
+                  // Identity
+                  {"PauliX",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyPauliX(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                   }},
+                  {"PauliY",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyPauliY(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                   }},
+                  {"PauliZ",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyPauliZ(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                   }},
+                  {"Hadamard",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyHadamard(std::forward<decltype(wires)>(wires),
+                                     std::forward<decltype(adjoint)>(adjoint),
+                                     std::forward<decltype(params)>(params));
+                   }},
+                  {"S",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyS(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                   }},
+                  {"T",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyT(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                   }},
+                  {"RX",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyRX(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                   }},
+                  {"RY",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyRY(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                   }},
+                  {"RZ",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyRZ(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                   }},
+                  {"PhaseShift",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyPhaseShift(std::forward<decltype(wires)>(wires),
+                                       std::forward<decltype(adjoint)>(adjoint),
+                                       std::forward<decltype(params)>(params));
+                   }},
+                  {"Rot",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyRot(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CY",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCY(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                   }},
+                  {"CZ",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCZ(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                   }},
+                  {"CNOT",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCNOT(std::forward<decltype(wires)>(wires),
+                                 std::forward<decltype(adjoint)>(adjoint),
+                                 std::forward<decltype(params)>(params));
+                   }},
+                  {"SWAP",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applySWAP(std::forward<decltype(wires)>(wires),
+                                 std::forward<decltype(adjoint)>(adjoint),
+                                 std::forward<decltype(params)>(params));
+                   }},
+                  {"ControlledPhaseShift",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyControlledPhaseShift(
+                           std::forward<decltype(wires)>(wires),
+                           std::forward<decltype(adjoint)>(adjoint),
+                           std::forward<decltype(params)>(params));
+                   }},
+                  {"CRX",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCRX(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CRY",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCRY(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CRZ",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCRZ(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CRot",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCRot(std::forward<decltype(wires)>(wires),
+                                 std::forward<decltype(adjoint)>(adjoint),
+                                 std::forward<decltype(params)>(params));
+                   }},
+                  {"IsingXX",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyIsingXX(std::forward<decltype(wires)>(wires),
                                     std::forward<decltype(adjoint)>(adjoint),
                                     std::forward<decltype(params)>(params));
-                  }},
-                 {"S",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyS(std::forward<decltype(wires)>(wires),
-                             std::forward<decltype(adjoint)>(adjoint),
-                             std::forward<decltype(params)>(params));
-                 }},
-                 {"T",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyT(std::forward<decltype(wires)>(wires),
-                             std::forward<decltype(adjoint)>(adjoint),
-                             std::forward<decltype(params)>(params));
-                  }},
-                 {"RX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyRX(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"RY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyRY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"RZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyRZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"PhaseShift",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyPhaseShift(std::forward<decltype(wires)>(wires),
-                                      std::forward<decltype(adjoint)>(adjoint),
-                                      std::forward<decltype(params)>(params));
-                  }},
-                 {"Rot",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyRot(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                  }},
-                 {"CY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"CZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"CNOT",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCNOT(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                  }},
-                 {"SWAP",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applySWAP(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                  }},
-                 {"ControlledPhaseShift",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyControlledPhaseShift(
-                          std::forward<decltype(wires)>(wires),
-                          std::forward<decltype(adjoint)>(adjoint),
-                          std::forward<decltype(params)>(params));
-                  }},
-                 {"CRX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCRX(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                  }},
-                 {"CRY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCRY(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                  }},
-                 {"CRZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCRZ(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                  }},
-                 {"CRot",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCRot(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                  }},                  
-                  {"IsingXX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyIsingXX(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
+                   }},
                   {"IsingXY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyIsingXY(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyIsingXY(std::forward<decltype(wires)>(wires),
+                                    std::forward<decltype(adjoint)>(adjoint),
+                                    std::forward<decltype(params)>(params));
+                   }},
 
                   {"IsingYY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyIsingYY(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyIsingYY(std::forward<decltype(wires)>(wires),
+                                    std::forward<decltype(adjoint)>(adjoint),
+                                    std::forward<decltype(params)>(params));
+                   }},
 
                   {"IsingZZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyIsingZZ(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"SingleExcitation",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applySingleExcitation(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"SingleExcitationMinus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"SingleExcitationPlus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"DoubleExcitation",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyDoubleExcitation(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"DoubleExcitationMinus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"DoubleExcitationPlus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }},
-                 {"MultiRZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyMultiRZ(std::forward<decltype(wires)>(wires),
-                                 std::forward<decltype(adjoint)>(adjoint),
-                                 std::forward<decltype(params)>(params));
-                  }},
-                 {"CSWAP",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyCSWAP(std::forward<decltype(wires)>(wires),
-                                 std::forward<decltype(adjoint)>(adjoint),
-                                 std::forward<decltype(params)>(params));
-                  }},
-                 {"Toffoli",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      applyToffoli(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                  }}
-                 },
-            generator_{
-                {"RX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorRX(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                {"RY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorRY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                {"RZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorRZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-		{"ControlledPhaseShift",
-                  [&](auto &&wires, auto &&adjoint, auto &&params) {
-                      return applyGeneratorControlledPhaseShift(
-                          std::forward<decltype(wires)>(wires),
-                          std::forward<decltype(adjoint)>(adjoint),
-                          std::forward<decltype(params)>(params));
-                  }},
-                {"CRX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorCRX(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"CRY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorCRY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                 {"CRZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorCRZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                  {"IsingXX",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorIsingXX(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                  {"IsingXY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorIsingXY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                  {"IsingYY",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorIsingYY(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                  {"IsingZZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorIsingZZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyIsingZZ(std::forward<decltype(wires)>(wires),
+                                    std::forward<decltype(adjoint)>(adjoint),
+                                    std::forward<decltype(params)>(params));
+                   }},
                   {"SingleExcitation",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorSingleExcitation(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applySingleExcitation(std::forward<decltype(wires)>(wires),
+                                             std::forward<decltype(adjoint)>(adjoint),
+                                             std::forward<decltype(params)>(params));
+                   }},
                   {"SingleExcitationMinus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorSingleExcitationMinus(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                                  std::forward<decltype(adjoint)>(adjoint),
+                                                  std::forward<decltype(params)>(params));
+                   }},
                   {"SingleExcitationPlus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorSingleExcitationPlus(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                                 std::forward<decltype(adjoint)>(adjoint),
+                                                 std::forward<decltype(params)>(params));
+                   }},
                   {"DoubleExcitation",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorDoubleExcitation(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyDoubleExcitation(std::forward<decltype(wires)>(wires),
+                                             std::forward<decltype(adjoint)>(adjoint),
+                                             std::forward<decltype(params)>(params));
+                   }},
                   {"DoubleExcitationMinus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                                  std::forward<decltype(adjoint)>(adjoint),
+                                                  std::forward<decltype(params)>(params));
+                   }},
                   {"DoubleExcitationPlus",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-                  {"PhaseShift",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorPhaseShift(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                                 std::forward<decltype(adjoint)>(adjoint),
+                                                 std::forward<decltype(params)>(params));
+                   }},
                   {"MultiRZ",
-                  [&](auto &&wires, auto &&adjoint, auto &&params){
-                      return applyGeneratorMultiRZ(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                  }},
-            }
-    {
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyMultiRZ(std::forward<decltype(wires)>(wires),
+                                    std::forward<decltype(adjoint)>(adjoint),
+                                    std::forward<decltype(params)>(params));
+                   }},
+                  {"CSWAP",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyCSWAP(std::forward<decltype(wires)>(wires),
+                                  std::forward<decltype(adjoint)>(adjoint),
+                                  std::forward<decltype(params)>(params));
+                   }},
+                  {"Toffoli",
+                   [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       applyToffoli(std::forward<decltype(wires)>(wires),
+                                    std::forward<decltype(adjoint)>(adjoint),
+                                    std::forward<decltype(params)>(params));
+                   }}},
+              generator_{
+                  {"RX", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorRX(std::forward<decltype(wires)>(wires),
+                                               std::forward<decltype(adjoint)>(adjoint),
+                                               std::forward<decltype(params)>(params));
+                   }},
+                  {"RY", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorRY(std::forward<decltype(wires)>(wires),
+                                               std::forward<decltype(adjoint)>(adjoint),
+                                               std::forward<decltype(params)>(params));
+                   }},
+                  {"RZ", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorRZ(std::forward<decltype(wires)>(wires),
+                                               std::forward<decltype(adjoint)>(adjoint),
+                                               std::forward<decltype(params)>(params));
+                   }},
+                  {"ControlledPhaseShift", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorControlledPhaseShift(
+                           std::forward<decltype(wires)>(wires),
+                           std::forward<decltype(adjoint)>(adjoint),
+                           std::forward<decltype(params)>(params));
+                   }},
+                  {"CRX", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorCRX(std::forward<decltype(wires)>(wires),
+                                                std::forward<decltype(adjoint)>(adjoint),
+                                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CRY", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorCRY(std::forward<decltype(wires)>(wires),
+                                                std::forward<decltype(adjoint)>(adjoint),
+                                                std::forward<decltype(params)>(params));
+                   }},
+                  {"CRZ", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorCRZ(std::forward<decltype(wires)>(wires),
+                                                std::forward<decltype(adjoint)>(adjoint),
+                                                std::forward<decltype(params)>(params));
+                   }},
+                  {"IsingXX", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorIsingXX(std::forward<decltype(wires)>(wires),
+                                                    std::forward<decltype(adjoint)>(adjoint),
+                                                    std::forward<decltype(params)>(params));
+                   }},
+                  {"IsingXY", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorIsingXY(std::forward<decltype(wires)>(wires),
+                                                    std::forward<decltype(adjoint)>(adjoint),
+                                                    std::forward<decltype(params)>(params));
+                   }},
+                  {"IsingYY", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorIsingYY(std::forward<decltype(wires)>(wires),
+                                                    std::forward<decltype(adjoint)>(adjoint),
+                                                    std::forward<decltype(params)>(params));
+                   }},
+                  {"IsingZZ", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorIsingZZ(std::forward<decltype(wires)>(wires),
+                                                    std::forward<decltype(adjoint)>(adjoint),
+                                                    std::forward<decltype(params)>(params));
+                   }},
+                  {"SingleExcitation", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorSingleExcitation(std::forward<decltype(wires)>(wires),
+                                                             std::forward<decltype(adjoint)>(adjoint),
+                                                             std::forward<decltype(params)>(params));
+                   }},
+                  {"SingleExcitationMinus", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorSingleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                                                  std::forward<decltype(adjoint)>(adjoint),
+                                                                  std::forward<decltype(params)>(params));
+                   }},
+                  {"SingleExcitationPlus", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorSingleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                                                 std::forward<decltype(adjoint)>(adjoint),
+                                                                 std::forward<decltype(params)>(params));
+                   }},
+                  {"DoubleExcitation", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorDoubleExcitation(std::forward<decltype(wires)>(wires),
+                                                             std::forward<decltype(adjoint)>(adjoint),
+                                                             std::forward<decltype(params)>(params));
+                   }},
+                  {"DoubleExcitationMinus", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                                                  std::forward<decltype(adjoint)>(adjoint),
+                                                                  std::forward<decltype(params)>(params));
+                   }},
+                  {"DoubleExcitationPlus", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                                                 std::forward<decltype(adjoint)>(adjoint),
+                                                                 std::forward<decltype(params)>(params));
+                   }},
+                  {"PhaseShift", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorPhaseShift(std::forward<decltype(wires)>(wires),
+                                                       std::forward<decltype(adjoint)>(adjoint),
+                                                       std::forward<decltype(params)>(params));
+                   }},
+                  {"MultiRZ", [&](auto &&wires, auto &&adjoint, auto &&params)
+                   {
+                       return applyGeneratorMultiRZ(std::forward<decltype(wires)>(wires),
+                                                    std::forward<decltype(adjoint)>(adjoint),
+                                                    std::forward<decltype(params)>(params));
+                   }},
+              }
+        {
         expval_funcs_["Identity"] = [&](auto &&wires, auto &&params) {
             return getExpectationValueIdentity(
                 std::forward<decltype(wires)>(wires),
@@ -903,6 +935,32 @@ template <class Precision> class StateVectorKokkos {
     }
 
     /**
+     * @brief Templated method that applies special n-qbit gates.
+     *
+     * @param wires Wires to apply gate to.
+     * @param inverse Indicates whether to use adjoint of gate.
+     * @param params parameters for this gate
+     */
+    template <template <class, bool> class functor_t, int nqbits>
+    void applySpecialQubitGate(
+        const std::vector<size_t> &wires, bool inverse = false,
+        [[maybe_unused]] const std::vector<Precision> &params = {}) {
+        auto &&num_qubits = getNumQubits();
+        assert(wires.size() == nqbits);
+        if (!inverse) {
+            Kokkos::parallel_for(
+                Kokkos::RangePolicy<KokkosExecSpace>(
+                    0, Util::exp2(num_qubits - nqbits)),
+                functor_t<Precision, false>(*data_, num_qubits, wires, params));
+        } else {
+            Kokkos::parallel_for(
+                Kokkos::RangePolicy<KokkosExecSpace>(
+                    0, Util::exp2(num_qubits - nqbits)),
+                functor_t<Precision, true>(*data_, num_qubits, wires, params));
+        }
+    }
+
+    /**
      * @brief Apply a PauliX operator to the state vector using a matrix
      *
      * @param wires Wires to apply gate to.
@@ -912,19 +970,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliX(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliXFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyPauliXFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -937,19 +983,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliY(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliYFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyPauliYFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -963,19 +997,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliZ(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliZFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyPauliZFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1259,19 +1281,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyHadamard(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyHadamardFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyHadamardFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyHadamardFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1283,19 +1293,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyS(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applySFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applySFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applySFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1307,19 +1305,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyT(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyTFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyTFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyTFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1331,20 +1317,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRX(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRXFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyRXFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1356,19 +1329,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRY(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyRYFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1380,19 +1341,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRZFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyRZFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1405,20 +1354,8 @@ template <class Precision> class StateVectorKokkos {
     void applyPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPhaseShiftFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params[0]));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPhaseShiftFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params[0]));
-        }
+        applySpecialQubitGate<applyPhaseShiftFunctor, 1>(wires, inverse,
+                                                         params);
     }
 
     /**
@@ -1430,19 +1367,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRot(const std::vector<size_t> &wires, bool inverse,
                   const std::vector<Precision> &params) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRotFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyRotFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyRotFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1453,20 +1378,8 @@ template <class Precision> class StateVectorKokkos {
      * @param params parameters for this gate
      */
     void applyCY(const std::vector<size_t> &wires, bool inverse = false,
-                 [[maybe_unused]] const std::vector<Precision> &param = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCYFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCYFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
+        applySpecialQubitGate<applyCYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1478,19 +1391,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCZFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCZFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyCZFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1502,19 +1403,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCNOT(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCNOTFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyCNOTFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyCNOTFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1526,19 +1415,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applySWAP(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySWAPFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySWAPFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applySWAPFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1552,22 +1429,8 @@ template <class Precision> class StateVectorKokkos {
     void applyControlledPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyControlledPhaseShiftFunctor<Precision, false>(
-                    *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyControlledPhaseShiftFunctor<Precision, true>(
-                    *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyControlledPhaseShiftFunctor, 2>(
+            wires, inverse, params);
     }
 
     /**
@@ -1579,19 +1442,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRX(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRXFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyCRXFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1603,19 +1454,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRY(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyCRYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1627,20 +1466,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRZ(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRZFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyCRZFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1652,20 +1478,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRot(const std::vector<size_t> &wires, bool inverse,
                    [[maybe_unused]] const std::vector<Precision> &params) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRotFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyCRotFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyCRotFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1678,19 +1491,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXX(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingXXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingXXFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyIsingXXFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1703,19 +1504,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingXYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingXYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyIsingXYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1728,19 +1517,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingYY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingYYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingYYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyIsingYYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1753,20 +1530,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingZZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingZZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyIsingZZFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyIsingZZFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1780,20 +1544,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applySingleExcitationFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applySingleExcitationFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applySingleExcitationFunctor, 2>(wires, inverse,
+                                                               params);
     }
 
     /**
@@ -1807,22 +1559,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySingleExcitationMinusFunctor<Precision, false>(
-                    *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySingleExcitationMinusFunctor<Precision, true>(
-                    *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applySingleExcitationMinusFunctor, 2>(
+            wires, inverse, params);
     }
 
     /**
@@ -1836,22 +1574,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySingleExcitationPlusFunctor<Precision, false>(
-                    *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applySingleExcitationPlusFunctor<Precision, true>(
-                    *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applySingleExcitationPlusFunctor, 2>(
+            wires, inverse, params);
     }
 
     /**
@@ -1865,20 +1589,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 4)),
-                                 applyDoubleExcitationFunctor<Precision, false>(
-                                     *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 4)),
-                                 applyDoubleExcitationFunctor<Precision, true>(
-                                     *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyDoubleExcitationFunctor, 4>(wires, inverse,
+                                                               params);
     }
 
     /**
@@ -1892,22 +1604,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyDoubleExcitationMinusFunctor<Precision, false>(
-                    *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyDoubleExcitationMinusFunctor<Precision, true>(
-                    *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyDoubleExcitationMinusFunctor, 4>(
+            wires, inverse, params);
     }
 
     /**
@@ -1921,22 +1619,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyDoubleExcitationPlusFunctor<Precision, false>(
-                    *data_, num_qubits, wires, params));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyDoubleExcitationPlusFunctor<Precision, true>(
-                    *data_, num_qubits, wires, params));
-        }
+        applySpecialQubitGate<applyDoubleExcitationPlusFunctor, 4>(
+            wires, inverse, params);
     }
 
     /**
@@ -1974,20 +1658,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyCSWAP(const std::vector<size_t> &wires, bool inverse = false,
                [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 3);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 3)),
-                applyCSWAPFunctor<Precision, false>(*data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 3)),
-                applyCSWAPFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyCSWAPFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -2000,20 +1671,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyToffoli(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 3);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 3)),
-                                 applyToffoliFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 3)),
-                                 applyToffoliFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyToffoliFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -2027,22 +1685,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyGeneratorPhaseShiftFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyGeneratorPhaseShiftFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorPhaseShiftFunctor, 1>(
+            wires, inverse, params);
         return static_cast<Precision>(1.0);
     }
 
@@ -2057,20 +1701,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingXXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingXXFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorIsingXXFunctor, 2>(wires, inverse,
+                                                               params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2085,20 +1717,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingXYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingXYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorIsingXYFunctor, 2>(wires, inverse,
+                                                               params);
         return static_cast<Precision>(0.5);
     }
 
@@ -2113,20 +1733,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingYYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingYYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorIsingYYFunctor, 2>(wires, inverse,
+                                                               params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2141,20 +1749,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingZZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorIsingZZFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorIsingZZFunctor, 2>(wires, inverse,
+                                                               params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2170,22 +1766,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorSingleExcitationFunctor, 2>(
+            wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2201,22 +1783,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationMinusFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationMinusFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorSingleExcitationMinusFunctor, 2>(
+            wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2232,22 +1800,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationPlusFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorSingleExcitationPlusFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorSingleExcitationPlusFunctor, 2>(
+            wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2263,22 +1817,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorDoubleExcitationFunctor, 4>(
+            wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2294,22 +1834,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationMinusFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationMinusFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorDoubleExcitationMinusFunctor, 4>(
+            wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2325,22 +1851,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 4);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationPlusFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 4)),
-                applyGeneratorDoubleExcitationPlusFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorDoubleExcitationPlusFunctor, 4>(
+            wires, inverse, params);
         return static_cast<Precision>(0.5);
     }
 
@@ -2355,20 +1867,7 @@ template <class Precision> class StateVectorKokkos {
     applyGeneratorRX(const std::vector<size_t> &wires, bool inverse = false,
                      [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliXFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applyPauliX(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2383,20 +1882,7 @@ template <class Precision> class StateVectorKokkos {
     applyGeneratorRY(const std::vector<size_t> &wires, bool inverse = false,
                      [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliYFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applyPauliY(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2411,20 +1897,7 @@ template <class Precision> class StateVectorKokkos {
     applyGeneratorRZ(const std::vector<size_t> &wires, bool inverse = false,
                      [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 1);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 1)),
-                                 applyPauliZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 1)),
-                applyPauliZFunctor<Precision, true>(*data_, num_qubits, wires));
-        }
+        applyPauliZ(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2440,22 +1913,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorControlledPhaseShiftFunctor<Precision, false>(
-                    *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
-                    0, Util::exp2(num_qubits - 2)),
-                applyGeneratorControlledPhaseShiftFunctor<Precision, true>(
-                    *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorControlledPhaseShiftFunctor, 2>(
+            wires, inverse, params);
         return static_cast<Precision>(1);
     }
 
@@ -2471,20 +1930,8 @@ template <class Precision> class StateVectorKokkos {
         [[maybe_unused]] const std::vector<Precision> &params = {})
 
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (!inverse) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRXFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRXFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorCRXFunctor, 2>(wires, inverse,
+                                                           params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2499,20 +1946,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRYFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRYFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorCRYFunctor, 2>(wires, inverse,
+                                                           params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -2527,20 +1962,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        auto &&num_qubits = getNumQubits();
-        assert(wires.size() == 2);
-
-        if (inverse == false) {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRZFunctor<Precision, false>(
-                                     *data_, num_qubits, wires));
-        } else {
-            Kokkos::parallel_for(Kokkos::RangePolicy<KokkosExecSpace>(
-                                     0, Util::exp2(num_qubits - 2)),
-                                 applyGeneratorCRZFunctor<Precision, true>(
-                                     *data_, num_qubits, wires));
-        }
+        applySpecialQubitGate<applyGeneratorCRZFunctor, 2>(wires, inverse,
+                                                           params);
         return -static_cast<Precision>(0.5);
     }
 

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -78,360 +78,328 @@ template <class Precision> class StateVectorKokkos {
 
     StateVectorKokkos() = delete;
     StateVectorKokkos(size_t num_qubits, const Kokkos::InitArguments &kokkos_args = {})
-            : gates_{
-                  // Identity
-                  {"PauliX",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyPauliX(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                   }},
-                  {"PauliY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyPauliY(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                   }},
-                  {"PauliZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyPauliZ(std::forward<decltype(wires)>(wires),
-                                   std::forward<decltype(adjoint)>(adjoint),
-                                   std::forward<decltype(params)>(params));
-                   }},
-                  {"Hadamard",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyHadamard(std::forward<decltype(wires)>(wires),
-                                     std::forward<decltype(adjoint)>(adjoint),
-                                     std::forward<decltype(params)>(params));
-                   }},
-                  {"S",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyS(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                   }},
-                  {"T",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyT(std::forward<decltype(wires)>(wires),
-                              std::forward<decltype(adjoint)>(adjoint),
-                              std::forward<decltype(params)>(params));
-                   }},
-                  {"RX",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyRX(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                   }},
-                  {"RY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyRY(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                   }},
-                  {"RZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyRZ(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                   }},
-                  {"PhaseShift",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyPhaseShift(std::forward<decltype(wires)>(wires),
-                                       std::forward<decltype(adjoint)>(adjoint),
-                                       std::forward<decltype(params)>(params));
-                   }},
-                  {"Rot",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyRot(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCY(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                   }},
-                  {"CZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCZ(std::forward<decltype(wires)>(wires),
-                               std::forward<decltype(adjoint)>(adjoint),
-                               std::forward<decltype(params)>(params));
-                   }},
-                  {"CNOT",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCNOT(std::forward<decltype(wires)>(wires),
-                                 std::forward<decltype(adjoint)>(adjoint),
-                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"SWAP",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applySWAP(std::forward<decltype(wires)>(wires),
-                                 std::forward<decltype(adjoint)>(adjoint),
-                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"ControlledPhaseShift",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyControlledPhaseShift(
-                           std::forward<decltype(wires)>(wires),
-                           std::forward<decltype(adjoint)>(adjoint),
-                           std::forward<decltype(params)>(params));
-                   }},
-                  {"CRX",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCRX(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CRY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCRY(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CRZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCRZ(std::forward<decltype(wires)>(wires),
-                                std::forward<decltype(adjoint)>(adjoint),
-                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CRot",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCRot(std::forward<decltype(wires)>(wires),
-                                 std::forward<decltype(adjoint)>(adjoint),
-                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingXX",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyIsingXX(std::forward<decltype(wires)>(wires),
-                                    std::forward<decltype(adjoint)>(adjoint),
-                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingXY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyIsingXY(std::forward<decltype(wires)>(wires),
-                                    std::forward<decltype(adjoint)>(adjoint),
-                                    std::forward<decltype(params)>(params));
-                   }},
-
-                  {"IsingYY",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyIsingYY(std::forward<decltype(wires)>(wires),
-                                    std::forward<decltype(adjoint)>(adjoint),
-                                    std::forward<decltype(params)>(params));
-                   }},
-
-                  {"IsingZZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyIsingZZ(std::forward<decltype(wires)>(wires),
-                                    std::forward<decltype(adjoint)>(adjoint),
-                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitation",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applySingleExcitation(std::forward<decltype(wires)>(wires),
-                                             std::forward<decltype(adjoint)>(adjoint),
-                                             std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitationMinus",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                                  std::forward<decltype(adjoint)>(adjoint),
-                                                  std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitationPlus",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                                 std::forward<decltype(adjoint)>(adjoint),
-                                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitation",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyDoubleExcitation(std::forward<decltype(wires)>(wires),
-                                             std::forward<decltype(adjoint)>(adjoint),
-                                             std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitationMinus",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                                  std::forward<decltype(adjoint)>(adjoint),
-                                                  std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitationPlus",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                                 std::forward<decltype(adjoint)>(adjoint),
-                                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"MultiRZ",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyMultiRZ(std::forward<decltype(wires)>(wires),
-                                    std::forward<decltype(adjoint)>(adjoint),
-                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"CSWAP",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyCSWAP(std::forward<decltype(wires)>(wires),
+        : gates_{
+                //Identity
+                 {"PauliX", 
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyPauliX(std::forward<decltype(wires)>(wires),
                                   std::forward<decltype(adjoint)>(adjoint),
                                   std::forward<decltype(params)>(params));
-                   }},
-                  {"Toffoli",
-                   [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       applyToffoli(std::forward<decltype(wires)>(wires),
+                  }},
+                 {"PauliY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyPauliY(std::forward<decltype(wires)>(wires),
+                                  std::forward<decltype(adjoint)>(adjoint),
+                                  std::forward<decltype(params)>(params));
+                  }},
+                 {"PauliZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyPauliZ(std::forward<decltype(wires)>(wires),
+                                  std::forward<decltype(adjoint)>(adjoint),
+                                  std::forward<decltype(params)>(params));
+                  }},
+                 {"Hadamard",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyHadamard(std::forward<decltype(wires)>(wires),
                                     std::forward<decltype(adjoint)>(adjoint),
                                     std::forward<decltype(params)>(params));
-                   }}},
-              generator_{
-                  {"RX", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorRX(std::forward<decltype(wires)>(wires),
-                                               std::forward<decltype(adjoint)>(adjoint),
-                                               std::forward<decltype(params)>(params));
-                   }},
-                  {"RY", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorRY(std::forward<decltype(wires)>(wires),
-                                               std::forward<decltype(adjoint)>(adjoint),
-                                               std::forward<decltype(params)>(params));
-                   }},
-                  {"RZ", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorRZ(std::forward<decltype(wires)>(wires),
-                                               std::forward<decltype(adjoint)>(adjoint),
-                                               std::forward<decltype(params)>(params));
-                   }},
-                  {"ControlledPhaseShift", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorControlledPhaseShift(
-                           std::forward<decltype(wires)>(wires),
-                           std::forward<decltype(adjoint)>(adjoint),
-                           std::forward<decltype(params)>(params));
-                   }},
-                  {"CRX", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorCRX(std::forward<decltype(wires)>(wires),
-                                                std::forward<decltype(adjoint)>(adjoint),
-                                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CRY", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorCRY(std::forward<decltype(wires)>(wires),
-                                                std::forward<decltype(adjoint)>(adjoint),
-                                                std::forward<decltype(params)>(params));
-                   }},
-                  {"CRZ", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorCRZ(std::forward<decltype(wires)>(wires),
-                                                std::forward<decltype(adjoint)>(adjoint),
-                                                std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingXX", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorIsingXX(std::forward<decltype(wires)>(wires),
-                                                    std::forward<decltype(adjoint)>(adjoint),
-                                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingXY", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorIsingXY(std::forward<decltype(wires)>(wires),
-                                                    std::forward<decltype(adjoint)>(adjoint),
-                                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingYY", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorIsingYY(std::forward<decltype(wires)>(wires),
-                                                    std::forward<decltype(adjoint)>(adjoint),
-                                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"IsingZZ", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorIsingZZ(std::forward<decltype(wires)>(wires),
-                                                    std::forward<decltype(adjoint)>(adjoint),
-                                                    std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitation", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorSingleExcitation(std::forward<decltype(wires)>(wires),
-                                                             std::forward<decltype(adjoint)>(adjoint),
-                                                             std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitationMinus", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorSingleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                                                  std::forward<decltype(adjoint)>(adjoint),
-                                                                  std::forward<decltype(params)>(params));
-                   }},
-                  {"SingleExcitationPlus", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorSingleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                                                 std::forward<decltype(adjoint)>(adjoint),
-                                                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitation", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorDoubleExcitation(std::forward<decltype(wires)>(wires),
-                                                             std::forward<decltype(adjoint)>(adjoint),
-                                                             std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitationMinus", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
-                                                                  std::forward<decltype(adjoint)>(adjoint),
-                                                                  std::forward<decltype(params)>(params));
-                   }},
-                  {"DoubleExcitationPlus", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
-                                                                 std::forward<decltype(adjoint)>(adjoint),
-                                                                 std::forward<decltype(params)>(params));
-                   }},
-                  {"PhaseShift", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorPhaseShift(std::forward<decltype(wires)>(wires),
-                                                       std::forward<decltype(adjoint)>(adjoint),
-                                                       std::forward<decltype(params)>(params));
-                   }},
-                  {"MultiRZ", [&](auto &&wires, auto &&adjoint, auto &&params)
-                   {
-                       return applyGeneratorMultiRZ(std::forward<decltype(wires)>(wires),
-                                                    std::forward<decltype(adjoint)>(adjoint),
-                                                    std::forward<decltype(params)>(params));
-                   }},
-              }
-        {
+                  }},
+                 {"S",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyS(std::forward<decltype(wires)>(wires),
+                             std::forward<decltype(adjoint)>(adjoint),
+                             std::forward<decltype(params)>(params));
+                 }},
+                 {"T",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyT(std::forward<decltype(wires)>(wires),
+                             std::forward<decltype(adjoint)>(adjoint),
+                             std::forward<decltype(params)>(params));
+                  }},
+                 {"RX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyRX(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"RY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyRY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"RZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyRZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"PhaseShift",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyPhaseShift(std::forward<decltype(wires)>(wires),
+                                      std::forward<decltype(adjoint)>(adjoint),
+                                      std::forward<decltype(params)>(params));
+                  }},
+                 {"Rot",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyRot(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                  }},
+                 {"CY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"CZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"CNOT",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCNOT(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                  }},
+                 {"SWAP",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applySWAP(std::forward<decltype(wires)>(wires),
+                                std::forward<decltype(adjoint)>(adjoint),
+                                std::forward<decltype(params)>(params));
+                  }},
+                 {"ControlledPhaseShift",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyControlledPhaseShift(
+                          std::forward<decltype(wires)>(wires),
+                          std::forward<decltype(adjoint)>(adjoint),
+                          std::forward<decltype(params)>(params));
+                  }},
+                 {"CRX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCRX(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                  }},
+                 {"CRY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCRY(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                  }},
+                 {"CRZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCRZ(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                  }},
+                 {"CRot",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCRot(std::forward<decltype(wires)>(wires),
+                               std::forward<decltype(adjoint)>(adjoint),
+                               std::forward<decltype(params)>(params));
+                  }},                  
+                  {"IsingXX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyIsingXX(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                  {"IsingXY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyIsingXY(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+
+                  {"IsingYY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyIsingYY(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+
+                  {"IsingZZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyIsingZZ(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"SingleExcitation",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applySingleExcitation(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"SingleExcitationMinus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applySingleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"SingleExcitationPlus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applySingleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"DoubleExcitation",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyDoubleExcitation(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"DoubleExcitationMinus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"DoubleExcitationPlus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }},
+                 {"MultiRZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyMultiRZ(std::forward<decltype(wires)>(wires),
+                                 std::forward<decltype(adjoint)>(adjoint),
+                                 std::forward<decltype(params)>(params));
+                  }},
+                 {"CSWAP",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyCSWAP(std::forward<decltype(wires)>(wires),
+                                 std::forward<decltype(adjoint)>(adjoint),
+                                 std::forward<decltype(params)>(params));
+                  }},
+                 {"Toffoli",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      applyToffoli(std::forward<decltype(wires)>(wires),
+                                   std::forward<decltype(adjoint)>(adjoint),
+                                   std::forward<decltype(params)>(params));
+                  }}
+                 },
+            generator_{
+                {"RX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorRX(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                {"RY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorRY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                {"RZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorRZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+		{"ControlledPhaseShift",
+                  [&](auto &&wires, auto &&adjoint, auto &&params) {
+                      return applyGeneratorControlledPhaseShift(
+                          std::forward<decltype(wires)>(wires),
+                          std::forward<decltype(adjoint)>(adjoint),
+                          std::forward<decltype(params)>(params));
+                  }},
+                {"CRX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorCRX(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"CRY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorCRY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                 {"CRZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorCRZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"IsingXX",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorIsingXX(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"IsingXY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorIsingXY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"IsingYY",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorIsingYY(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"IsingZZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorIsingZZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"SingleExcitation",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorSingleExcitation(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"SingleExcitationMinus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorSingleExcitationMinus(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"SingleExcitationPlus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorSingleExcitationPlus(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"DoubleExcitation",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorDoubleExcitation(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"DoubleExcitationMinus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorDoubleExcitationMinus(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"DoubleExcitationPlus",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorDoubleExcitationPlus(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"PhaseShift",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorPhaseShift(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+                  {"MultiRZ",
+                  [&](auto &&wires, auto &&adjoint, auto &&params){
+                      return applyGeneratorMultiRZ(std::forward<decltype(wires)>(wires),
+                              std::forward<decltype(adjoint)>(adjoint),
+                              std::forward<decltype(params)>(params));
+                  }},
+            }
+    {
         expval_funcs_["Identity"] = [&](auto &&wires, auto &&params) {
             return getExpectationValueIdentity(
                 std::forward<decltype(wires)>(wires),

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -916,7 +916,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
         auto &&num_qubits = getNumQubits();
-        assert(wires.size() == nqubits);
+        PL_ASSERT(wires.size() == nqubits);
         if (!inverse) {
             Kokkos::parallel_for(
                 Kokkos::RangePolicy<KokkosExecSpace>(

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -912,7 +912,7 @@ template <class Precision> class StateVectorKokkos {
      * @param params parameters for this gate
      */
     template <template <class, bool> class functor_t, int nqbits>
-    void applySpecialQubitGate(
+    void applyGateFunctor(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
         auto &&num_qubits = getNumQubits();
@@ -940,7 +940,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliX(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<pauliXFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<pauliXFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -953,7 +953,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliY(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<pauliYFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<pauliYFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -967,7 +967,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyPauliZ(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<pauliZFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<pauliZFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1251,7 +1251,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyHadamard(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<hadamardFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<hadamardFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1263,7 +1263,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyS(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<sFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<sFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1275,7 +1275,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyT(const std::vector<size_t> &wires, bool inverse = false,
                 [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<tFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<tFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1287,7 +1287,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRX(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<rxFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<rxFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1299,7 +1299,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRY(const std::vector<size_t> &wires, bool inverse,
                  [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<ryFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<ryFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1311,7 +1311,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<rzFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<rzFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1324,7 +1324,7 @@ template <class Precision> class StateVectorKokkos {
     void applyPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<phaseShiftFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<phaseShiftFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1336,7 +1336,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyRot(const std::vector<size_t> &wires, bool inverse,
                   const std::vector<Precision> &params) {
-        applySpecialQubitGate<rotFunctor, 1>(wires, inverse, params);
+        applyGateFunctor<rotFunctor, 1>(wires, inverse, params);
     }
 
     /**
@@ -1348,7 +1348,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<cyFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<cyFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1360,7 +1360,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<czFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<czFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1372,7 +1372,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCNOT(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<cnotFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<cnotFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1384,7 +1384,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applySWAP(const std::vector<size_t> &wires, bool inverse = false,
                    [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<swapFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<swapFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1398,8 +1398,8 @@ template <class Precision> class StateVectorKokkos {
     void applyControlledPhaseShift(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<controlledPhaseShiftFunctor, 2>(wires, inverse,
-                                                              params);
+        applyGateFunctor<controlledPhaseShiftFunctor, 2>(wires, inverse,
+                                                         params);
     }
 
     /**
@@ -1411,7 +1411,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRX(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<crxFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<crxFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1423,7 +1423,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRY(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<cryFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<cryFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1435,7 +1435,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRZ(const std::vector<size_t> &wires, bool inverse = false,
                   [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<crzFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<crzFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1447,7 +1447,7 @@ template <class Precision> class StateVectorKokkos {
      */
     void applyCRot(const std::vector<size_t> &wires, bool inverse,
                    [[maybe_unused]] const std::vector<Precision> &params) {
-        applySpecialQubitGate<cRotFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<cRotFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1460,7 +1460,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXX(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<isingXXFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<isingXXFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1473,7 +1473,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingXY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<isingXYFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<isingXYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1486,7 +1486,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingYY(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<isingYYFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<isingYYFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1499,7 +1499,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyIsingZZ(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<isingZZFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<isingZZFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1513,8 +1513,7 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<singleExcitationFunctor, 2>(wires, inverse,
-                                                          params);
+        applyGateFunctor<singleExcitationFunctor, 2>(wires, inverse, params);
     }
 
     /**
@@ -1528,8 +1527,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<singleExcitationMinusFunctor, 2>(wires, inverse,
-                                                               params);
+        applyGateFunctor<singleExcitationMinusFunctor, 2>(wires, inverse,
+                                                          params);
     }
 
     /**
@@ -1543,8 +1542,8 @@ template <class Precision> class StateVectorKokkos {
     void applySingleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<singleExcitationPlusFunctor, 2>(wires, inverse,
-                                                              params);
+        applyGateFunctor<singleExcitationPlusFunctor, 2>(wires, inverse,
+                                                         params);
     }
 
     /**
@@ -1558,8 +1557,7 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitation(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<doubleExcitationFunctor, 4>(wires, inverse,
-                                                          params);
+        applyGateFunctor<doubleExcitationFunctor, 4>(wires, inverse, params);
     }
 
     /**
@@ -1573,8 +1571,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationMinus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<doubleExcitationMinusFunctor, 4>(wires, inverse,
-                                                               params);
+        applyGateFunctor<doubleExcitationMinusFunctor, 4>(wires, inverse,
+                                                          params);
     }
 
     /**
@@ -1588,8 +1586,8 @@ template <class Precision> class StateVectorKokkos {
     void applyDoubleExcitationPlus(
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<doubleExcitationPlusFunctor, 4>(wires, inverse,
-                                                              params);
+        applyGateFunctor<doubleExcitationPlusFunctor, 4>(wires, inverse,
+                                                         params);
     }
 
     /**
@@ -1627,7 +1625,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyCSWAP(const std::vector<size_t> &wires, bool inverse = false,
                [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<cSWAPFunctor, 3>(wires, inverse, params);
+        applyGateFunctor<cSWAPFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -1640,7 +1638,7 @@ template <class Precision> class StateVectorKokkos {
     void
     applyToffoli(const std::vector<size_t> &wires, bool inverse = false,
                  [[maybe_unused]] const std::vector<Precision> &params = {}) {
-        applySpecialQubitGate<toffoliFunctor, 3>(wires, inverse, params);
+        applyGateFunctor<toffoliFunctor, 3>(wires, inverse, params);
     }
 
     /**
@@ -1654,8 +1652,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorPhaseShiftFunctor, 1>(wires, inverse,
-                                                             params);
+        applyGateFunctor<generatorPhaseShiftFunctor, 1>(wires, inverse, params);
         return static_cast<Precision>(1.0);
     }
 
@@ -1670,8 +1667,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorIsingXXFunctor, 2>(wires, inverse,
-                                                          params);
+        applyGateFunctor<generatorIsingXXFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1686,8 +1682,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorIsingXYFunctor, 2>(wires, inverse,
-                                                          params);
+        applyGateFunctor<generatorIsingXYFunctor, 2>(wires, inverse, params);
         return static_cast<Precision>(0.5);
     }
 
@@ -1702,8 +1697,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorIsingYYFunctor, 2>(wires, inverse,
-                                                          params);
+        applyGateFunctor<generatorIsingYYFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1718,8 +1712,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorIsingZZFunctor, 2>(wires, inverse,
-                                                          params);
+        applyGateFunctor<generatorIsingZZFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1735,8 +1728,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorSingleExcitationFunctor, 2>(
-            wires, inverse, params);
+        applyGateFunctor<generatorSingleExcitationFunctor, 2>(wires, inverse,
+                                                              params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1752,7 +1745,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorSingleExcitationMinusFunctor, 2>(
+        applyGateFunctor<generatorSingleExcitationMinusFunctor, 2>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1769,7 +1762,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorSingleExcitationPlusFunctor, 2>(
+        applyGateFunctor<generatorSingleExcitationPlusFunctor, 2>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1786,8 +1779,8 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorDoubleExcitationFunctor, 4>(
-            wires, inverse, params);
+        applyGateFunctor<generatorDoubleExcitationFunctor, 4>(wires, inverse,
+                                                              params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1803,7 +1796,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorDoubleExcitationMinusFunctor, 4>(
+        applyGateFunctor<generatorDoubleExcitationMinusFunctor, 4>(
             wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
@@ -1820,7 +1813,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorDoubleExcitationPlusFunctor, 4>(
+        applyGateFunctor<generatorDoubleExcitationPlusFunctor, 4>(
             wires, inverse, params);
         return static_cast<Precision>(0.5);
     }
@@ -1882,7 +1875,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorControlledPhaseShiftFunctor, 2>(
+        applyGateFunctor<generatorControlledPhaseShiftFunctor, 2>(
             wires, inverse, params);
         return static_cast<Precision>(1);
     }
@@ -1899,7 +1892,7 @@ template <class Precision> class StateVectorKokkos {
         [[maybe_unused]] const std::vector<Precision> &params = {})
 
         -> Precision {
-        applySpecialQubitGate<generatorCRXFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<generatorCRXFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1914,7 +1907,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorCRYFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<generatorCRYFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 
@@ -1929,7 +1922,7 @@ template <class Precision> class StateVectorKokkos {
         const std::vector<size_t> &wires, bool inverse = false,
         [[maybe_unused]] const std::vector<Precision> &params = {})
         -> Precision {
-        applySpecialQubitGate<generatorCRZFunctor, 2>(wires, inverse, params);
+        applyGateFunctor<generatorCRZFunctor, 2>(wires, inverse, params);
         return -static_cast<Precision>(0.5);
     }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The class `StateVectorKokkos` has methods to apply special gates (e.g. PauliX) which can be expressed in terms of a templated method.

**Description of the Change:**
Add templated method `applySpecialQubitGate`.
Unify functor interfaces adding a sometimes unused `params` input.
 
**Benefits:**
Reduce boilerplate. 

**Possible Drawbacks:**
Longer compilation time.

**Related GitHub Issues:**
