### PR TITLE
Validate all wheels with twine check

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Improvements
 
+* Wheels are now checked with `twine check` post-creation for PyPI compatibility.
+  [(#50)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/50)
+
 * Template n-qubit gate methods.
 [(#40)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/40)
 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -90,8 +90,14 @@ jobs:
 
           CIBW_BUILD_VERBOSITY: 3
 
-        run: | 
+        run: 
           python3.8 -m cibuildwheel --output-dir wheelhouse
+
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -95,8 +95,8 @@ jobs:
 
       - name: Validate wheels
         run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
+          python3.8 -m pip install twine
+          python3.8 -m twine check ./wheelhouse/*.whl
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** To avoid creating wheels that are incompatible with PyPI, we should validate all wheels post build to ensure they can be safely uploaded when ready.

**Description of the Change:** Adds a `twine check` command to validate each wheel after the CIBuildWheel step completes.

**Benefits:** Ensures the wheels are PyPI compatible.

**Possible Drawbacks:**

**Related GitHub Issues:**
