### PR TITLE
Port device over to new return types specification

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -69,8 +69,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python -m pip uninstall pennylane -y
+          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
         run: |

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -138,8 +138,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          python -m pip uninstall pennylane -y
+          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
         run: |
@@ -206,8 +207,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          python -m pip uninstall pennylane -y
+          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           # Sync with latest master branches
           python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
           
       - name: Checkout pennyLane-lightning-kokkos
         uses: actions/checkout@v3

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -77,7 +77,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
+
       - name: Install ML libraries for interfaces
         run: |
           pip install --upgrade torch==${{ env.TORCH_VERSION }} -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -23,7 +23,7 @@ from itertools import product
 import re
 import numpy as np
 from pennylane import (
-    active_return
+    active_return,
     math,
     QubitDevice,
     BasisState,
@@ -678,7 +678,7 @@ if CPP_BINARY_AVAILABLE:
 
             for op_idx, tp in enumerate(trainable_params):
                 # get op_idx-th operator among differentiable operators
-                op, _, _= tape.get_operation(op_idx, return_op_index=True)  
+                op, _, _ = tape.get_operation(op_idx, return_op_index=True)
 
                 if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
                     # We now just ignore non-op or state preps
@@ -735,9 +735,7 @@ if CPP_BINARY_AVAILABLE:
                     new_tape = tape.copy()
                     new_tape._measurements = [qml.expval(ham)]
 
-                    return self.adjoint_jacobian(
-                        new_tape, starting_state, use_device_state
-                    )
+                    return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
                 return processing_fn
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -677,7 +677,7 @@ def test_integration(returns):
 
     def circuit(params):
         circuit_ansatz(params, wires=range(4))
-        return qml.expval(returns), qml.expval(qml.PauliY(1))
+        return np.array([qml.expval(returns), qml.expval(qml.PauliY(1))])
 
     n_params = 30
     params = np.linspace(0, 10, n_params)
@@ -720,7 +720,7 @@ def test_integration_custom_wires(returns):
 
     def circuit(params):
         circuit_ansatz(params, wires=custom_wires)
-        return qml.expval(returns), qml.expval(qml.PauliY(custom_wires[1]))
+        return np.array([qml.expval(returns), qml.expval(qml.PauliY(custom_wires[1]))])
 
     n_params = 30
     params = np.linspace(0, 10, n_params)


### PR DESCRIPTION
Context:

With Pennylane PR #3957: https://github.com/PennyLaneAI/pennylane/pull/3957 , the new return types system is enabled by default.

To make sure lightning works with pennylane master, we need to change the return shape from adjoint_jacobian. The return shape from execute in handled inside QubitDevice.

Possible Drawbacks:
None

Related GitHub Issues:
None