### PR TITLE
port changes from lightning

### DIFF
--- a/pennylane_lightning_kokkos/_serialize.py
+++ b/pennylane_lightning_kokkos/_serialize.py
@@ -20,13 +20,14 @@ import numpy as np
 from pennylane import (
     BasisState,
     Hadamard,
-    Projector,
+    PauliX,
+    PauliY,
+    PauliZ,
+    Identity,
     QubitStateVector,
     Rot,
 )
-from pennylane.grouping import is_pauli_word
-from pennylane.operation import Observable, Tensor
-from pennylane.ops.qubit.observables import Hermitian
+from pennylane.operation import Tensor
 from pennylane.ops.op_math import Adjoint
 from pennylane.tape import QuantumTape
 
@@ -46,29 +47,16 @@ try:
         HamiltonianKokkos_C128,
         SparseHamiltonianKokkos_C64,
         SparseHamiltonianKokkos_C128,
-        HermitianObsKokkos_C64,
-        HermitianObsKokkos_C128,
     )
 except ImportError as e:
     print(e)
 
-
-def _obs_has_kernel(obs: Observable) -> bool:
-    """Returns True if the input observable has a supported kernel in the C++ backend.
-
-    Args:
-        obs (Observable): the input observable
-
-    Returns:
-        bool: indicating whether ``obs`` has a dedicated kernel in the backend
-    """
-    if is_pauli_word(obs):
-        return True
-    if isinstance(obs, (Hadamard, Projector)):
-        return True
-    if isinstance(obs, Tensor):
-        return all(_obs_has_kernel(o) for o in obs.obs)
-    return False
+pauli_name_map = {
+    "I": "Identity",
+    "X": "PauliX",
+    "Y": "PauliY",
+    "Z": "PauliZ",
+}
 
 
 def _serialize_named_ob(o, wires_map: dict, use_csingle: bool):
@@ -82,19 +70,11 @@ def _serialize_named_ob(o, wires_map: dict, use_csingle: bool):
     Returns:
         named_obs (NamedObsKokkos_C64 or NamedObsKokkos_C128): A Named observable object compatible with the C++ backend
     """
-    assert not isinstance(o, Tensor)
-
-    if use_csingle:
-        ctype = np.complex64
-        named_obs = NamedObsKokkos_C64
-    else:
-        ctype = np.complex128
-        named_obs = NamedObsKokkos_C128
-
-    wires_list = o.wires.tolist()
-    wires = [wires_map[w] for w in wires_list]
-    if _obs_has_kernel(o):
-        return named_obs(o.name, wires)
+    named_obs = NamedObsKokkos_C64 if use_csingle else NamedObsKokkos_C128
+    wires = [wires_map[w] for w in o.wires]
+    if o.name == "Identity":
+        wires = wires[:1]
+    return named_obs(o.name, wires)
 
 
 def _serialize_tensor_ob(ob, wires_map: dict, use_csingle: bool):
@@ -172,26 +152,37 @@ def _serialize_sparsehamiltonian(ob, wires_map: dict, use_csingle: bool):
     return sparsehamiltonian_obs(data, indices, offsets, wires)
 
 
-def _serialize_hermitian(ob, wires_map: dict, use_csingle: bool):
-    """Serialize an observable (Hermitian)
+def _serialize_pauli_word(ob, wires_map: dict, use_csingle: bool):
+    """Serialize a :class:`pennylane.pauli.PauliWord` into a Named or Tensor observable."""
+    if use_csingle:
+        named_obs = NamedObsKokkos_C64
+        tensor_obs = TensorProdObsKokkos_C64
+    else:
+        named_obs = NamedObsKokkos_C128
+        tensor_obs = TensorProdObsKokkos_C128
 
-    Args:
-        o (Observable): the input observable (Hermitian)
-        wire_map (dict): a dictionary mapping input wires to the device's backend wires
-        use_csingle (bool): whether to use np.complex64 instead of np.complex128
+    if len(ob) == 1:
+        wire, pauli = list(ob.items())[0]
+        return named_obs(pauli_name_map[pauli], [wires_map[wire]])
 
-    Returns:
-        hermitian_obs (HermitianObsKokkos_C64 or HermitianObsKokkos_C128): A Hermitian observable object compatible with the C++ backend
-    """
+    return tensor_obs(
+        [named_obs(pauli_name_map[pauli], [wires_map[wire]]) for wire, pauli in ob.items()]
+    )
+
+
+def _serialize_pauli_sentence(ob, wires_map: dict, use_csingle: bool):
+    """Serialize a :class:`pennylane.pauli.PauliSentence` into a Hamiltonian."""
     if use_csingle:
         rtype = np.float32
-        hermitian_obs = HermitianObsKokkos_C64
+        hamiltonian_obs = HamiltonianKokkos_C64
     else:
         rtype = np.float64
-        hermitian_obs = HermitianObsKokkos_C128
+        hamiltonian_obs = HamiltonianKokkos_C128
 
-    data = qml.matrix(ob).astype(rtype).ravel(order="C")
-    return hermitian_obs(data, ob.wires.tolist())
+    pwords, coeffs = zip(*ob.items())
+    terms = [_serialize_pauli_word(pw, wires_map, use_csingle) for pw in pwords]
+    coeffs = np.array(coeffs).astype(rtype)
+    return hamiltonian_obs(coeffs, terms)
 
 
 def _serialize_ob(ob, wires_map, use_csingle):
@@ -209,12 +200,16 @@ def _serialize_ob(ob, wires_map, use_csingle):
         return _serialize_hamiltonian(ob, wires_map, use_csingle)
     elif ob.name == "SparseHamiltonian":
         return _serialize_sparsehamiltonian(ob, wires_map, use_csingle)
+    elif isinstance(ob, (PauliX, PauliY, PauliZ, Identity, Hadamard)):
+        return _serialize_named_ob(ob, wires_map, use_csingle)
+    elif ob._pauli_rep is not None:
+        return _serialize_pauli_sentence(ob._pauli_rep, wires_map, use_csingle)
     elif ob.name == "Hermitian":
         raise TypeError(
-            f"Hermitian observables are not currently supported for adjoint differentiation. Please use Pauli-words only."
+            "Hermitian observables are not currently supported for adjoint differentiation. Please use Pauli-words only."
         )
     else:
-        return _serialize_named_ob(ob, wires_map, use_csingle)
+        raise TypeError(f"Unknown observable found: {ob}. Please use Pauli-words only.")
 
 
 def _serialize_observables(tape: QuantumTape, wires_map: dict, use_csingle: bool = False) -> List:

--- a/pennylane_lightning_kokkos/_serialize.py
+++ b/pennylane_lightning_kokkos/_serialize.py
@@ -47,6 +47,8 @@ try:
         HamiltonianKokkos_C128,
         SparseHamiltonianKokkos_C64,
         SparseHamiltonianKokkos_C128,
+        HermitianObsKokkos_C64,
+        HermitianObsKokkos_C128,
     )
 except ImportError as e:
     print(e)
@@ -150,6 +152,28 @@ def _serialize_sparsehamiltonian(ob, wires_map: dict, use_csingle: bool):
     wires.extend([wires_map[w] for w in wires_list])
 
     return sparsehamiltonian_obs(data, indices, offsets, wires)
+
+
+def _serialize_hermitian(ob, wires_map: dict, use_csingle: bool):
+    """Serialize an observable (Hermitian)
+
+    Args:
+        o (Observable): the input observable (Hermitian)
+        wire_map (dict): a dictionary mapping input wires to the device's backend wires
+        use_csingle (bool): whether to use np.complex64 instead of np.complex128
+
+    Returns:
+        hermitian_obs (HermitianObsKokkos_C64 or HermitianObsKokkos_C128): A Hermitian observable object compatible with the C++ backend
+    """
+    if use_csingle:
+        rtype = np.float32
+        hermitian_obs = HermitianObsKokkos_C64
+    else:
+        rtype = np.float64
+        hermitian_obs = HermitianObsKokkos_C128
+
+    data = qml.matrix(ob).astype(rtype).ravel(order="C")
+    return hermitian_obs(data, ob.wires.tolist())
 
 
 def _serialize_pauli_word(ob, wires_map: dict, use_csingle: bool):

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -179,6 +179,9 @@ if CPP_BINARY_AVAILABLE:
             "SparseHamiltonian",
             "Hamiltonian",
             "Identity",
+            "Sum",
+            "Prod",
+            "SProd",
         }
 
         def __init__(
@@ -738,6 +741,19 @@ if CPP_BINARY_AVAILABLE:
                     return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
                 return processing_fn
+
+        def _get_diagonalizing_gates(self, circuit: qml.tape.QuantumTape) -> List[Operation]:
+            skip_diagonalizing = lambda obs: isinstance(obs, qml.Hamiltonian) or (
+                isinstance(obs, qml.ops.Sum) and obs._pauli_rep is not None
+            )
+            meas_filtered = list(
+                filter(
+                    lambda m: m.obs is None or not skip_diagonalizing(m.obs), circuit.measurements
+                )
+            )
+            return super()._get_diagonalizing_gates(
+                qml.tape.QuantumScript(measurements=meas_filtered)
+            )
 
 else:  # CPP_BINARY_AVAILABLE:
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -681,7 +681,7 @@ if CPP_BINARY_AVAILABLE:
 
             for op_idx, tp in enumerate(trainable_params):
                 # get op_idx-th operator among differentiable operators
-                op, _, _ = tape.get_operation(op_idx, return_op_index=True)
+                op, _, _ = tape.get_operation(op_idx)
 
                 if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
                     # We now just ignore non-op or state preps

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -22,12 +22,17 @@ from pennylane import numpy as np
 from pennylane import QNode, qnode
 from scipy.stats import unitary_group
 import pennylane_lightning_kokkos as plk
+from pennylane_lightning_kokkos._serialize import _serialize_ob
 from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import (
     InitArguments,
     NamedObsKokkos_C64,
+    NamedObsKokkos_C128,
     TensorProdObsKokkos_C64,
+    TensorProdObsKokkos_C128,
     HamiltonianKokkos_C64,
+    HamiltonianKokkos_C128,
     SparseHamiltonianKokkos_C64,
+    SparseHamiltonianKokkos_C128,
 )
 
 from pennylane import (
@@ -955,25 +960,29 @@ def test_integration_custom_wires_batching(returns):
 
 
 @pytest.mark.parametrize(
-    "obs,obs_type",
+    "obs,obs_type_c64,obs_type_c128",
     [
-        (qml.PauliZ(0), NamedObsKokkos_C64),
-        (qml.PauliZ(0) @ qml.PauliZ(1), TensorProdObsKokkos_C64),
-        (qml.Hadamard(0), NamedObsKokkos_C64),
-        (qml.Hamiltonian([1], [qml.PauliZ(0)]), HamiltonianKokkos_C64),
+        (qml.PauliZ(0), NamedObsKokkos_C64, NamedObsKokkos_C128),
+        (qml.PauliZ(0) @ qml.PauliZ(1), TensorProdObsKokkos_C64, TensorProdObsKokkos_C128),
+        (qml.Hadamard(0), NamedObsKokkos_C64, NamedObsKokkos_C128),
+        (qml.Hamiltonian([1], [qml.PauliZ(0)]), HamiltonianKokkos_C64, HamiltonianKokkos_C128),
         (
             qml.PauliZ(0) @ qml.Hadamard(1) @ (0.1 * (qml.PauliZ(2) + qml.PauliX(3))),
             TensorProdObsKokkos_C64,
+            TensorProdObsKokkos_C128,
         ),
         (
             qml.SparseHamiltonian(qml.Hamiltonian([1], [qml.PauliZ(0)]).sparse_matrix(), wires=[0]),
             SparseHamiltonianKokkos_C64,
+            SparseHamiltonianKokkos_C128,
         ),
     ],
 )
-def test_obs_returns_expected_type(obs, obs_type):
+@pytest.mark.parametrize("use_csingle", [True, False])
+def test_obs_returns_expected_type(obs, obs_type_c64, obs_type_c128, use_csingle):
     """Tests that observables get serialized to the expected type."""
-    assert isinstance(plk._serialize._serialize_ob(obs, dict(enumerate(obs.wires)), True), obs_type)
+    obs_type = obs_type_c64 if use_csingle else obs_type_c128
+    assert isinstance(_serialize_ob(obs, dict(enumerate(obs.wires)), use_csingle), obs_type)
 
 
 @pytest.mark.parametrize(
@@ -986,7 +995,8 @@ def test_obs_returns_expected_type(obs, obs_type):
         qml.sum(qml.Hadamard(0), qml.PauliX(1)),
     ],
 )
-def test_obs_not_supported_for_adjoint_diff(bad_obs):
+@pytest.mark.parametrize("use_csingle", [True, False])
+def test_obs_not_supported_for_adjoint_diff(bad_obs, use_csingle):
     """Tests observables that can't be serialized for adjoint-differentiation."""
     with pytest.raises(TypeError, match="Please use Pauli-words only."):
-        plk._serialize._serialize_ob(bad_obs, dict(enumerate(bad_obs.wires)), True)
+        _serialize_ob(bad_obs, dict(enumerate(bad_obs.wires)), use_csingle)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -22,7 +22,13 @@ from pennylane import numpy as np
 from pennylane import QNode, qnode
 from scipy.stats import unitary_group
 import pennylane_lightning_kokkos as plk
-from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import InitArguments
+from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import (
+    InitArguments,
+    NamedObsKokkos_C64,
+    TensorProdObsKokkos_C64,
+    HamiltonianKokkos_C64,
+    SparseHamiltonianKokkos_C64,
+)
 
 from pennylane import (
     QuantumFunctionError,
@@ -370,6 +376,25 @@ class TestAdjointJacobian:
         dM2 = dev_kokkos.adjoint_jacobian(tape, starting_state=state_vector)
 
         assert np.allclose(dM1, dM2, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize(
+        "old_obs",
+        [
+            qml.PauliX(0) @ qml.PauliZ(1),
+            qml.Hamiltonian([1.1], [qml.PauliZ(0)]),
+            qml.Hamiltonian([1.1, 2.2], [qml.PauliZ(0), qml.PauliZ(1)]),
+            qml.Hamiltonian([1.1, 2.2], [qml.PauliX(0), qml.PauliZ(0) @ qml.PauliX(1)]),
+        ],
+    )
+    def test_op_arithmetic_is_supported(self, old_obs, dev_kokkos):
+        """Tests that an arithmetic obs with a PauliRep are supported for adjoint_jacobian."""
+        ops = [qml.RX(1.1, 0), qml.RY(2.2, 0), qml.RX(0.66, 1), qml.RY(1.23, 1)]
+        new_obs = qml.pauli.pauli_sentence(old_obs).operation()
+        old_tape = qml.tape.QuantumScript(ops, [qml.expval(old_obs)])
+        new_tape = qml.tape.QuantumScript(ops, [qml.expval(new_obs)])
+        old_res = dev_kokkos.adjoint_jacobian(old_tape)
+        new_res = dev_kokkos.adjoint_jacobian(new_tape)
+        assert qml.math.allequal(old_res, new_res)
 
 
 class TestAdjointJacobianQNode:
@@ -927,3 +952,41 @@ def test_integration_custom_wires_batching(returns):
     j_lightning = qml.jacobian(convert_to_array_lightning)(params)
 
     assert np.allclose(j_kokkos, j_lightning, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    "obs,obs_type",
+    [
+        (qml.PauliZ(0), NamedObsKokkos_C64),
+        (qml.PauliZ(0) @ qml.PauliZ(1), TensorProdObsKokkos_C64),
+        (qml.Hadamard(0), NamedObsKokkos_C64),
+        (qml.Hamiltonian([1], [qml.PauliZ(0)]), HamiltonianKokkos_C64),
+        (
+            qml.PauliZ(0) @ qml.Hadamard(1) @ (0.1 * (qml.PauliZ(2) + qml.PauliX(3))),
+            TensorProdObsKokkos_C64,
+        ),
+        (
+            qml.SparseHamiltonian(qml.Hamiltonian([1], [qml.PauliZ(0)]).sparse_matrix(), wires=[0]),
+            SparseHamiltonianKokkos_C64,
+        ),
+    ],
+)
+def test_obs_returns_expected_type(obs, obs_type):
+    """Tests that observables get serialized to the expected type."""
+    assert isinstance(plk._serialize._serialize_ob(obs, dict(enumerate(obs.wires)), True), obs_type)
+
+
+@pytest.mark.parametrize(
+    "bad_obs",
+    [
+        qml.Hermitian(np.eye(2), wires=0),
+        qml.sum(qml.PauliZ(0), qml.Hadamard(1)),
+        qml.Projector([0], wires=0),
+        qml.PauliZ(0) @ qml.Projector([0], wires=1),
+        qml.sum(qml.Hadamard(0), qml.PauliX(1)),
+    ],
+)
+def test_obs_not_supported_for_adjoint_diff(bad_obs):
+    """Tests observables that can't be serialized for adjoint-differentiation."""
+    with pytest.raises(TypeError, match="Please use Pauli-words only."):
+        plk._serialize._serialize_ob(bad_obs, dict(enumerate(bad_obs.wires)), True)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -150,3 +150,27 @@ def test_inverse_unitary_correct(op, op_name):
     unitary_expected = qml.matrix(qml.adjoint(op[0](*op[1], **op[2])))
 
     assert np.allclose(unitary, unitary_expected)
+
+
+@pytest.mark.skipif(not LightningKokkos._CPP_BINARY_AVAILABLE, reason="LightningKokkos unsupported")
+@pytest.mark.parametrize(
+    "obs,has_rotation",
+    [
+        (qml.Hamiltonian([1], [qml.PauliY(0)]), False),
+        (qml.sum(qml.PauliZ(0), qml.PauliX(1)), False),
+        (qml.PauliX(0), True),
+        (qml.sum(qml.PauliZ(0), qml.Hermitian(qml.PauliX(1).matrix(), 1)), True),
+    ],
+)
+def test_get_diagonalizing_gates(obs, has_rotation):
+    """Tests that _get_diagonalizing_gates filters measurements as expected."""
+    dev = qml.device("lightning.kokkos", wires=2)
+    qs = qml.tape.QuantumScript(measurements=[qml.expval(obs)])
+    actual = dev._get_diagonalizing_gates(qs)
+    if has_rotation:
+        expected = obs.diagonalizing_gates()
+        assert len(actual) == len(expected)
+        for rot_actual, rot_expected in zip(actual, expected):
+            assert qml.equal(rot_actual, rot_expected)
+    else:
+        assert len(actual) == 0


### PR DESCRIPTION
Changes ported over from PennyLaneAI/pennylane-lightning#424

Quite a bit had to be re-jigged a bit, but the test I added runs `dev.adjoint_jacobian` on various tapes with old-school and new-school observables and ensures that they are the same, which seems promising to me!

Note: I linked the GPU PR to this one below, but I'll address reviews here and port over whatever's needed before requesting a review on that one.