### PR TITLE
Remove deprecated set-output commands.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Improvements
 
+* Remove deprecated `set-output` commands from workflow files.
+[(#56)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/56)
+
 * `setup.py` works on MacOS without `brew` (which is required by Conda-Forge runners).
 [(#48)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/48)
 

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -41,27 +41,27 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})"
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }} \
-              --range)"
+              --range)" >> $GITHUB_OUTPUT
           fi
 
       - name: Kokkos execution strategy (CPU)
         id: cpu_exec_model
-        run: echo "::set-output name=cpu_exec_model::[\"SERIAL\",\"OPENMP\"]"
+        run: echo "cpu_exec_model=[\"SERIAL\",\"OPENMP\"]" >> $GITHUB_OUTPUT
 
       - name: Kokkos execution strategy (MacOS)
         id: macos_exec_model
-        run: echo "::set-output name=macos_exec_model::[\"SERIAL\",\"THREADS\"]"
+        run: echo "macos_exec_model=[\"SERIAL\",\"THREADS\"]" >> $GITHUB_OUTPUT
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "::set-output name=kokkos_version::[\"3.7.00\"]"
+        run: echo "kokkos_version=[\"3.7.00\"]" >> $GITHUB_OUTPUT
 
     outputs:
       python_version: ${{ steps.pyver.outputs.python_version }}


### PR DESCRIPTION
**Context:**
`save-state` and `set-output` commands will be deprecated. 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Description of the Change:**
Use new env files instead of `save-state` and `set-output` commands.

**Benefits:**
CI will keep running.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
