### PR TITLE
Deprecate/init arguments

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Improvements
 
+* Replace deprecated InitArguments by InitializationSettings.
+[(#57)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/57)
+
 * `setup.py` works on MacOS without `brew` (which is required by Conda-Forge runners).
 [(#48)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/48)
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -52,7 +52,7 @@ from ._version import __version__
 
 try:
     from .lightning_kokkos_qubit_ops import (
-        InitArguments,
+        InitializationSettings,
         LightningKokkos_C128,
         LightningKokkos_C64,
         AdjointJacobianKokkos_C128,
@@ -159,7 +159,7 @@ if CPP_BINARY_AVAILABLE:
             wires (int): the number of wires to initialize the device with
             sync (bool): immediately sync with host-sv after applying operations
             c_dtype: Datatypes for statevector representation. Must be one of ``np.complex64`` or ``np.complex128``.
-            kokkos_args (InitArguments): binding for Kokkos::InitArguments (threading parameters).
+            kokkos_args (InitializationSettings): binding for Kokkos::InitializationSettings (threading parameters).
         """
 
         name = "PennyLane plugin for Kokkos-backed Lightning device"
@@ -202,10 +202,10 @@ if CPP_BINARY_AVAILABLE:
             super().__init__(wires, shots=shots, r_dtype=r_dtype, c_dtype=c_dtype)
             if kokkos_args is None:
                 self._kokkos_state = _kokkos_dtype(c_dtype)(self.num_wires)
-            elif isinstance(kokkos_args, InitArguments):
+            elif isinstance(kokkos_args, InitializationSettings):
                 self._kokkos_state = _kokkos_dtype(c_dtype)(self.num_wires, kokkos_args)
             else:
-                raise TypeError("Argument kokkos_args must be of type InitArguments.")
+                raise TypeError("Argument kokkos_args must be of type InitializationSettings.")
             self._sync = sync
 
             if not LightningKokkos.kokkos_config:

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -66,6 +66,7 @@ try:
         SparseHamiltonianKokkos_C64,
         SparseHamiltonianKokkos_C128,
         kokkos_config_info,
+        print_configuration,
     )
 
     from ._serialize import _serialize_observables, _serialize_ops
@@ -83,11 +84,12 @@ def _kokkos_dtype(dtype):
 
 
 def _kokkos_configuration():
-    config_info = kokkos_config_info()
-    for key in config_info.keys():
-        if "Runtime Configuration" in key:
-            for sub_key, value in config_info[key].items():
-                config_info[key][sub_key] = re.sub("\x00", ":", value)
+    config_info = print_configuration()
+    # config_info = kokkos_config_info()
+    # for key in config_info.keys():
+    #     if "Runtime Configuration" in key:
+    #         for sub_key, value in config_info[key].items():
+    #             config_info[key][sub_key] = re.sub("\x00", ":", value)
     return config_info
 
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -84,12 +84,12 @@ def _kokkos_dtype(dtype):
 
 
 def _kokkos_configuration():
-    config_info = print_configuration()
-    # config_info = kokkos_config_info()
-    # for key in config_info.keys():
-    #     if "Runtime Configuration" in key:
-    #         for sub_key, value in config_info[key].items():
-    #             config_info[key][sub_key] = re.sub("\x00", ":", value)
+    # config_info = print_configuration()
+    config_info = kokkos_config_info()
+    for key in config_info.keys():
+        if "Runtime Configuration" in key:
+            for sub_key, value in config_info[key].items():
+                config_info[key][sub_key] = re.sub("\x00", ":", value)
     return config_info
 
 

--- a/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
@@ -50,775 +50,762 @@ namespace py = pybind11;
 template <class PrecisionT, class ParamT>
 void StateVectorKokkos_class_bindings(py::module &m) {
 
-    using np_arr_r =
-        py::array_t<ParamT, py::array::c_style | py::array::forcecast>;
-    using np_arr_c = py::array_t<std::complex<ParamT>,
-                                 py::array::c_style | py::array::forcecast>;
+  using np_arr_r =
+      py::array_t<ParamT, py::array::c_style | py::array::forcecast>;
+  using np_arr_c = py::array_t<std::complex<ParamT>,
+                               py::array::c_style | py::array::forcecast>;
 
-    // Enable module name to be based on size of complex datatype
-    const std::string bitsize =
-        std::to_string(sizeof(std::complex<PrecisionT>) * 8);
-    std::string class_name = "LightningKokkos_C" + bitsize;
+  // Enable module name to be based on size of complex datatype
+  const std::string bitsize =
+      std::to_string(sizeof(std::complex<PrecisionT>) * 8);
+  std::string class_name = "LightningKokkos_C" + bitsize;
 
-    py::class_<StateVectorKokkos<PrecisionT>>(m, class_name.c_str())
-        .def(py::init([](std::size_t num_qubits) {
-            return new StateVectorKokkos<PrecisionT>(num_qubits);
-        }))
-        .def(py::init([](std::size_t num_qubits,
-                         const Kokkos::InitArguments &kokkos_args) {
-            return new StateVectorKokkos<PrecisionT>(num_qubits, kokkos_args);
-        }))
-        .def(py::init([](const np_arr_c &arr) {
-            py::buffer_info numpyArrayInfo = arr.request();
+  py::class_<StateVectorKokkos<PrecisionT>>(m, class_name.c_str())
+      .def(py::init([](std::size_t num_qubits) {
+        return new StateVectorKokkos<PrecisionT>(num_qubits);
+      }))
+      .def(py::init([](std::size_t num_qubits,
+                       const Kokkos::InitializationSettings &kokkos_args) {
+        return new StateVectorKokkos<PrecisionT>(num_qubits, kokkos_args);
+      }))
+      .def(py::init([](const np_arr_c &arr) {
+        py::buffer_info numpyArrayInfo = arr.request();
+        auto *data_ptr =
+            static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
+        return new StateVectorKokkos<PrecisionT>(
+            data_ptr, static_cast<std::size_t>(arr.size()));
+      }))
+      .def(py::init([](const np_arr_c &arr,
+                       const Kokkos::InitializationSettings &kokkos_args) {
+        py::buffer_info numpyArrayInfo = arr.request();
+        auto *data_ptr =
+            static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
+        return new StateVectorKokkos<PrecisionT>(
+            data_ptr, static_cast<std::size_t>(arr.size()), kokkos_args);
+      }))
+      .def(
+          "setBasisState",
+          [](StateVectorKokkos<PrecisionT> &sv, const size_t index) {
+            sv.setBasisState(index);
+          },
+          "Create Basis State on Device.")
+      .def(
+          "setStateVector",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &indices, const np_arr_c &state) {
+            const auto buffer = state.request();
+            std::vector<Kokkos::complex<ParamT>> state_kok;
+            if (buffer.size) {
+              const auto ptr =
+                  static_cast<const Kokkos::complex<ParamT> *>(buffer.ptr);
+              state_kok =
+                  std::vector<Kokkos::complex<ParamT>>{ptr, ptr + buffer.size};
+            }
+            sv.setStateVector(indices, state_kok);
+          },
+          "Set State Vector on device with values and their corresponding "
+          "indices for the state vector on device")
+      .def(
+          "Identity",
+          []([[maybe_unused]] StateVectorKokkos<PrecisionT> &sv,
+             [[maybe_unused]] const std::vector<std::size_t> &wires,
+             [[maybe_unused]] bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {},
+          "Apply the Identity gate.")
+      .def(
+          "PauliX",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyPauliX(wires, adjoint);
+          },
+          "Apply the PauliX gate.")
+
+      .def(
+          "PauliY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyPauliY(wires, adjoint);
+          },
+          "Apply the PauliY gate.")
+
+      .def(
+          "PauliZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyPauliZ(wires, adjoint);
+          },
+          "Apply the PauliZ gate.")
+
+      .def(
+          "Hadamard",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyHadamard(wires, adjoint);
+          },
+          "Apply the Hadamard gate.")
+
+      .def(
+          "S",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyS(wires, adjoint);
+          },
+          "Apply the S gate.")
+
+      .def(
+          "T",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyT(wires, adjoint);
+          },
+          "Apply the T gate.")
+
+      .def(
+          "CNOT",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyCNOT(wires, adjoint);
+          },
+          "Apply the CNOT gate.")
+
+      .def(
+          "SWAP",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applySWAP(wires, adjoint);
+          },
+          "Apply the SWAP gate.")
+
+      .def(
+          "CSWAP",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyCSWAP(wires, adjoint);
+          },
+          "Apply the CSWAP gate.")
+
+      .def(
+          "Toffoli",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyToffoli(wires, adjoint);
+          },
+          "Apply the Toffoli gate.")
+
+      .def(
+          "CY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyCY(wires, adjoint);
+          },
+          "Apply the CY gate.")
+
+      .def(
+          "CZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             [[maybe_unused]] const std::vector<ParamT> &params) {
+            sv.applyCZ(wires, adjoint);
+          },
+          "Apply the CZ gate.")
+
+      .def(
+          "PhaseShift",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyPhaseShift(wires, adjoint, params);
+          },
+          "Apply the PhaseShift gate.")
+
+      .def("apply",
+           py::overload_cast<
+               const vector<string> &, const vector<vector<std::size_t>> &,
+               const vector<bool> &, const vector<vector<PrecisionT>> &>(
+               &StateVectorKokkos<PrecisionT>::applyOperation))
+
+      .def("apply", py::overload_cast<const vector<string> &,
+                                      const vector<vector<std::size_t>> &,
+                                      const vector<bool> &>(
+                        &StateVectorKokkos<PrecisionT>::applyOperation))
+      .def(
+          "apply",
+          [](StateVectorKokkos<PrecisionT> &sv, const std::string &str,
+             const vector<size_t> &wires, bool inv,
+             [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
+             [[maybe_unused]] const np_arr_c &gate_matrix) {
+            const auto m_buffer = gate_matrix.request();
+            std::vector<Kokkos::complex<ParamT>> conv_matrix;
+            if (m_buffer.size) {
+              const auto m_ptr =
+                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
+              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                  m_ptr, m_ptr + m_buffer.size};
+            }
+            sv.applyOperation_std(str, wires, inv, std::vector<ParamT>{},
+                                  conv_matrix);
+          },
+          "Apply operation via the gate matrix")
+      .def("applyGenerator",
+           py::overload_cast<const std::string &, const std::vector<size_t> &,
+                             bool, const vector<PrecisionT> &>(
+               &StateVectorKokkos<PrecisionT>::applyGenerator))
+      .def(
+          "ControlledPhaseShift",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyControlledPhaseShift(wires, adjoint, params);
+          },
+          "Apply the ControlledPhaseShift gate.")
+
+      .def(
+          "RX",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyRX(wires, adjoint, params);
+          },
+          "Apply the RX gate.")
+
+      .def(
+          "RY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyRY(wires, adjoint, params);
+          },
+          "Apply the RY gate.")
+
+      .def(
+          "RZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyRZ(wires, adjoint, params);
+          },
+          "Apply the RZ gate.")
+
+      .def(
+          "Rot",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyRot(wires, adjoint, params);
+          },
+          "Apply the Rot gate.")
+
+      .def(
+          "CRX",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyCRX(wires, adjoint, params);
+          },
+          "Apply the CRX gate.")
+
+      .def(
+          "CRY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyCRY(wires, adjoint, params);
+          },
+          "Apply the CRY gate.")
+
+      .def(
+          "CRZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyCRZ(wires, adjoint, params);
+          },
+          "Apply the CRZ gate.")
+
+      .def(
+          "CRot",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyCRot(wires, adjoint, params);
+          },
+          "Apply the CRot gate.")
+      .def(
+          "IsingXX",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyIsingXX(wires, adjoint, params);
+          },
+          "Apply the IsingXX gate.")
+      .def(
+          "IsingXY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            sv.applyIsingXY(wires, adjoint, params);
+          },
+          "Apply the IsingXY gate.")
+      .def(
+          "IsingYY",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyIsingYY(wires, adjoint, params);
+          },
+          "Apply the IsingYY gate.")
+      .def(
+          "IsingZZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyIsingZZ(wires, adjoint, params);
+          },
+          "Apply the IsingZZ gate.")
+      .def(
+          "MultiRZ",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyMultiRZ(wires, adjoint, params);
+          },
+          "Apply the MultiRZ gate.")
+      .def(
+          "SingleExcitation",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applySingleExcitation(wires, adjoint, params);
+          },
+          "Apply the SingleExcitation gate.")
+      .def(
+          "SingleExcitationMinus",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applySingleExcitationMinus(wires, adjoint, params);
+          },
+          "Apply the SingleExcitationMinus gate.")
+      .def(
+          "SingleExcitationPlus",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applySingleExcitationPlus(wires, adjoint, params);
+          },
+          "Apply the SingleExcitationPlus gate.")
+      .def(
+          "DoubleExcitation",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyDoubleExcitation(wires, adjoint, params);
+          },
+          "Apply the DoubleExcitation gate.")
+      .def(
+          "DoubleExcitationMinus",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyDoubleExcitationMinus(wires, adjoint, params);
+          },
+          "Apply the DoubleExcitationMinus gate.")
+      .def(
+          "DoubleExcitationPlus",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires, bool adjoint,
+             const std::vector<ParamT> &params) {
+            return sv.applyDoubleExcitationPlus(wires, adjoint, params);
+          },
+          "Apply the DoubleExcitationPlus gate.")
+      .def(
+          "ExpectationValue",
+          [](StateVectorKokkos<PrecisionT> &sv, const std::string &obsName,
+             const std::vector<std::size_t> &wires,
+             [[maybe_unused]] const std::vector<ParamT> &params,
+             [[maybe_unused]] const np_arr_c &gate_matrix) {
+            const auto m_buffer = gate_matrix.request();
+            std::vector<Kokkos::complex<ParamT>> conv_matrix;
+            if (m_buffer.size) {
+              auto m_ptr = static_cast<Kokkos::complex<ParamT> *>(m_buffer.ptr);
+              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                  m_ptr, m_ptr + m_buffer.size};
+            }
+            // Return the real component only
+            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                obsName, wires, params, conv_matrix);
+          },
+          "Calculate the expectation value of the given observable.")
+      .def(
+          "ExpectationValue",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::string> &obsName,
+             const std::vector<std::size_t> &wires,
+             [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
+             [[maybe_unused]] const np_arr_c &gate_matrix) {
+            std::string obs_concat{"#"};
+            for (const auto &sub : obsName) {
+              obs_concat += sub;
+            }
+            const auto m_buffer = gate_matrix.request();
+            std::vector<Kokkos::complex<ParamT>> conv_matrix;
+            if (m_buffer.size) {
+              const auto m_ptr =
+                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
+              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                  m_ptr, m_ptr + m_buffer.size};
+            }
+            // Return the real component only & ignore params
+            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                obs_concat, wires, std::vector<ParamT>{}, conv_matrix);
+          },
+          "Calculate the expectation value of the given observable.")
+      .def(
+          "ExpectationValue",
+          [](StateVectorKokkos<PrecisionT> &sv,
+             const std::vector<std::size_t> &wires,
+             const np_arr_c &gate_matrix) {
+            const auto m_buffer = gate_matrix.request();
+            std::vector<Kokkos::complex<ParamT>> conv_matrix;
+            if (m_buffer.size) {
+              const auto m_ptr =
+                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
+              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                  m_ptr, m_ptr + m_buffer.size};
+            }
+            // Return the real component only & ignore params
+            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                wires, conv_matrix);
+          },
+          "Calculate the expectation value of the given observable.")
+
+      .def(
+          "ExpectationValue",
+          [](StateVectorKokkos<PrecisionT> &sv, const np_arr_c &gate_data,
+             const std::vector<std::size_t> &indices,
+             const std::vector<std::size_t> &index_ptr) {
+            const auto m_buffer = gate_data.request();
+            std::vector<Kokkos::complex<ParamT>> conv_data;
+            if (m_buffer.size) {
+              const auto m_ptr =
+                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
+              conv_data = std::vector<Kokkos::complex<ParamT>>{
+                  m_ptr, m_ptr + m_buffer.size};
+            }
+            // Return the real component only & ignore params
+            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                conv_data, indices, index_ptr);
+          },
+          "Calculate the expectation value of the given observable.")
+      .def("probs",
+           [](StateVectorKokkos<PrecisionT> &sv,
+              const std::vector<size_t> &wires) {
+             auto m = MeasuresKokkos<PrecisionT>(sv);
+             if (wires.empty()) {
+               return py::array_t<ParamT>(py::cast(m.probs()));
+             }
+
+             const bool is_sorted_wires =
+                 std::is_sorted(wires.begin(), wires.end());
+
+             if (wires.size() == sv.getNumQubits()) {
+               if (is_sorted_wires)
+                 return py::array_t<ParamT>(py::cast(m.probs()));
+             }
+             return py::array_t<ParamT>(py::cast(m.probs(wires)));
+           })
+      .def("GenerateSamples",
+           [](StateVectorKokkos<PrecisionT> &sv, size_t num_wires,
+              size_t num_shots) {
+             auto &&result =
+                 MeasuresKokkos<PrecisionT>(sv).generate_samples(num_shots);
+
+             const size_t ndim = 2;
+             const std::vector<size_t> shape{num_shots, num_wires};
+             constexpr auto sz = sizeof(size_t);
+             const std::vector<size_t> strides{sz * num_wires, sz};
+             // return 2-D NumPy array
+             return py::array(py::buffer_info(
+                 result.data(), /* data as contiguous array  */
+                 sz,            /* size of one scalar        */
+                 py::format_descriptor<size_t>::format(), /* data type */
+                 ndim,   /* number of dimensions      */
+                 shape,  /* shape of the matrix       */
+                 strides /* strides for each axis     */
+                 ));
+           })
+      .def(
+          "DeviceToHost",
+          [](StateVectorKokkos<PrecisionT> &device_sv, np_arr_c &host_sv) {
+            py::buffer_info numpyArrayInfo = host_sv.request();
             auto *data_ptr =
                 static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-            return new StateVectorKokkos<PrecisionT>(
-                data_ptr, static_cast<std::size_t>(arr.size()));
-        }))
-        .def(py::init([](const np_arr_c &arr,
-                         const Kokkos::InitArguments &kokkos_args) {
-            py::buffer_info numpyArrayInfo = arr.request();
+            if (host_sv.size()) {
+              device_sv.DeviceToHost(data_ptr, host_sv.size());
+            }
+          },
+          "Synchronize data from the GPU device to host.")
+      .def("HostToDevice",
+           py::overload_cast<Kokkos::complex<PrecisionT> *, size_t>(
+               &StateVectorKokkos<PrecisionT>::HostToDevice),
+           "Synchronize data from the host device to GPU.")
+      .def(
+          "HostToDevice",
+          [](StateVectorKokkos<PrecisionT> &device_sv,
+             const np_arr_c &host_sv) {
+            const py::buffer_info numpyArrayInfo = host_sv.request();
             auto *data_ptr =
                 static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-            return new StateVectorKokkos<PrecisionT>(
-                data_ptr, static_cast<std::size_t>(arr.size()), kokkos_args);
-        }))
-        .def(
-            "setBasisState",
-            [](StateVectorKokkos<PrecisionT> &sv, const size_t index) {
-                sv.setBasisState(index);
-            },
-            "Create Basis State on Device.")
-        .def(
-            "setStateVector",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &indices, const np_arr_c &state) {
-                const auto buffer = state.request();
-                std::vector<Kokkos::complex<ParamT>> state_kok;
-                if (buffer.size) {
-                    const auto ptr =
-                        static_cast<const Kokkos::complex<ParamT> *>(
-                            buffer.ptr);
-                    state_kok = std::vector<Kokkos::complex<ParamT>>{
-                        ptr, ptr + buffer.size};
-                }
-                sv.setStateVector(indices, state_kok);
-            },
-            "Set State Vector on device with values and their corresponding "
-            "indices for the state vector on device")
-        .def(
-            "Identity",
-            []([[maybe_unused]] StateVectorKokkos<PrecisionT> &sv,
-               [[maybe_unused]] const std::vector<std::size_t> &wires,
-               [[maybe_unused]] bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {},
-            "Apply the Identity gate.")
-        .def(
-            "PauliX",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyPauliX(wires, adjoint);
-            },
-            "Apply the PauliX gate.")
+            const auto length = static_cast<size_t>(numpyArrayInfo.shape[0]);
+            if (length) {
+              device_sv.HostToDevice(data_ptr, length);
+            }
+          },
+          "Synchronize data from the host device to GPU.")
+      .def("numQubits", &StateVectorKokkos<PrecisionT>::getNumQubits)
+      .def("dataLength", &StateVectorKokkos<PrecisionT>::getLength)
+      .def("resetKokkos", &StateVectorKokkos<PrecisionT>::resetStateVector);
 
-        .def(
-            "PauliY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyPauliY(wires, adjoint);
-            },
-            "Apply the PauliY gate.")
+  //***********************************************************************//
+  //                              Observable
+  //***********************************************************************//
 
-        .def(
-            "PauliZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyPauliZ(wires, adjoint);
-            },
-            "Apply the PauliZ gate.")
+  class_name = "ObservableKokkos_C" + bitsize;
+  py::class_<ObservableKokkos<PrecisionT>,
+             std::shared_ptr<ObservableKokkos<PrecisionT>>>(
+      m, class_name.c_str(), py::module_local());
 
-        .def(
-            "Hadamard",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyHadamard(wires, adjoint);
-            },
-            "Apply the Hadamard gate.")
+  class_name = "NamedObsKokkos_C" + bitsize;
+  py::class_<NamedObsKokkos<PrecisionT>,
+             std::shared_ptr<NamedObsKokkos<PrecisionT>>,
+             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                           py::module_local())
+      .def(py::init(
+          [](const std::string &name, const std::vector<size_t> &wires) {
+            return NamedObsKokkos<PrecisionT>(name, wires);
+          }))
+      .def("__repr__", &NamedObsKokkos<PrecisionT>::getObsName)
+      .def("get_wires", &NamedObsKokkos<PrecisionT>::getWires,
+           "Get wires of observables")
+      .def(
+          "__eq__",
+          [](const NamedObsKokkos<PrecisionT> &self, py::handle other) -> bool {
+            if (!py::isinstance<NamedObsKokkos<PrecisionT>>(other)) {
+              return false;
+            }
+            auto other_cast = other.cast<NamedObsKokkos<PrecisionT>>();
+            return self == other_cast;
+          },
+          "Compare two observables");
 
-        .def(
-            "S",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyS(wires, adjoint);
-            },
-            "Apply the S gate.")
-
-        .def(
-            "T",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyT(wires, adjoint);
-            },
-            "Apply the T gate.")
-
-        .def(
-            "CNOT",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyCNOT(wires, adjoint);
-            },
-            "Apply the CNOT gate.")
-
-        .def(
-            "SWAP",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applySWAP(wires, adjoint);
-            },
-            "Apply the SWAP gate.")
-
-        .def(
-            "CSWAP",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyCSWAP(wires, adjoint);
-            },
-            "Apply the CSWAP gate.")
-
-        .def(
-            "Toffoli",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyToffoli(wires, adjoint);
-            },
-            "Apply the Toffoli gate.")
-
-        .def(
-            "CY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyCY(wires, adjoint);
-            },
-            "Apply the CY gate.")
-
-        .def(
-            "CZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               [[maybe_unused]] const std::vector<ParamT> &params) {
-                sv.applyCZ(wires, adjoint);
-            },
-            "Apply the CZ gate.")
-
-        .def(
-            "PhaseShift",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyPhaseShift(wires, adjoint, params);
-            },
-            "Apply the PhaseShift gate.")
-
-        .def("apply",
-             py::overload_cast<
-                 const vector<string> &, const vector<vector<std::size_t>> &,
-                 const vector<bool> &, const vector<vector<PrecisionT>> &>(
-                 &StateVectorKokkos<PrecisionT>::applyOperation))
-
-        .def("apply", py::overload_cast<const vector<string> &,
-                                        const vector<vector<std::size_t>> &,
-                                        const vector<bool> &>(
-                          &StateVectorKokkos<PrecisionT>::applyOperation))
-        .def(
-            "apply",
-            [](StateVectorKokkos<PrecisionT> &sv, const std::string &str,
-               const vector<size_t> &wires, bool inv,
-               [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
-               [[maybe_unused]] const np_arr_c &gate_matrix) {
-                const auto m_buffer = gate_matrix.request();
-                std::vector<Kokkos::complex<ParamT>> conv_matrix;
-                if (m_buffer.size) {
-                    const auto m_ptr =
-                        static_cast<const Kokkos::complex<ParamT> *>(
-                            m_buffer.ptr);
-                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                        m_ptr, m_ptr + m_buffer.size};
-                }
-                sv.applyOperation_std(str, wires, inv, std::vector<ParamT>{},
-                                      conv_matrix);
-            },
-            "Apply operation via the gate matrix")
-        .def("applyGenerator",
-             py::overload_cast<const std::string &, const std::vector<size_t> &,
-                               bool, const vector<PrecisionT> &>(
-                 &StateVectorKokkos<PrecisionT>::applyGenerator))
-        .def(
-            "ControlledPhaseShift",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyControlledPhaseShift(wires, adjoint, params);
-            },
-            "Apply the ControlledPhaseShift gate.")
-
-        .def(
-            "RX",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyRX(wires, adjoint, params);
-            },
-            "Apply the RX gate.")
-
-        .def(
-            "RY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyRY(wires, adjoint, params);
-            },
-            "Apply the RY gate.")
-
-        .def(
-            "RZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyRZ(wires, adjoint, params);
-            },
-            "Apply the RZ gate.")
-
-        .def(
-            "Rot",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyRot(wires, adjoint, params);
-            },
-            "Apply the Rot gate.")
-
-        .def(
-            "CRX",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyCRX(wires, adjoint, params);
-            },
-            "Apply the CRX gate.")
-
-        .def(
-            "CRY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyCRY(wires, adjoint, params);
-            },
-            "Apply the CRY gate.")
-
-        .def(
-            "CRZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyCRZ(wires, adjoint, params);
-            },
-            "Apply the CRZ gate.")
-
-        .def(
-            "CRot",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyCRot(wires, adjoint, params);
-            },
-            "Apply the CRot gate.")
-        .def(
-            "IsingXX",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyIsingXX(wires, adjoint, params);
-            },
-            "Apply the IsingXX gate.")
-        .def(
-            "IsingXY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                sv.applyIsingXY(wires, adjoint, params);
-            },
-            "Apply the IsingXY gate.")
-        .def(
-            "IsingYY",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyIsingYY(wires, adjoint, params);
-            },
-            "Apply the IsingYY gate.")
-        .def(
-            "IsingZZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyIsingZZ(wires, adjoint, params);
-            },
-            "Apply the IsingZZ gate.")
-        .def(
-            "MultiRZ",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyMultiRZ(wires, adjoint, params);
-            },
-            "Apply the MultiRZ gate.")
-        .def(
-            "SingleExcitation",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applySingleExcitation(wires, adjoint, params);
-            },
-            "Apply the SingleExcitation gate.")
-        .def(
-            "SingleExcitationMinus",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applySingleExcitationMinus(wires, adjoint, params);
-            },
-            "Apply the SingleExcitationMinus gate.")
-        .def(
-            "SingleExcitationPlus",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applySingleExcitationPlus(wires, adjoint, params);
-            },
-            "Apply the SingleExcitationPlus gate.")
-        .def(
-            "DoubleExcitation",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyDoubleExcitation(wires, adjoint, params);
-            },
-            "Apply the DoubleExcitation gate.")
-        .def(
-            "DoubleExcitationMinus",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyDoubleExcitationMinus(wires, adjoint, params);
-            },
-            "Apply the DoubleExcitationMinus gate.")
-        .def(
-            "DoubleExcitationPlus",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires, bool adjoint,
-               const std::vector<ParamT> &params) {
-                return sv.applyDoubleExcitationPlus(wires, adjoint, params);
-            },
-            "Apply the DoubleExcitationPlus gate.")
-        .def(
-            "ExpectationValue",
-            [](StateVectorKokkos<PrecisionT> &sv, const std::string &obsName,
-               const std::vector<std::size_t> &wires,
-               [[maybe_unused]] const std::vector<ParamT> &params,
-               [[maybe_unused]] const np_arr_c &gate_matrix) {
-                const auto m_buffer = gate_matrix.request();
-                std::vector<Kokkos::complex<ParamT>> conv_matrix;
-                if (m_buffer.size) {
-                    auto m_ptr =
-                        static_cast<Kokkos::complex<ParamT> *>(m_buffer.ptr);
-                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                        m_ptr, m_ptr + m_buffer.size};
-                }
-                // Return the real component only
-                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                    obsName, wires, params, conv_matrix);
-            },
-            "Calculate the expectation value of the given observable.")
-        .def(
-            "ExpectationValue",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::string> &obsName,
-               const std::vector<std::size_t> &wires,
-               [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
-               [[maybe_unused]] const np_arr_c &gate_matrix) {
-                std::string obs_concat{"#"};
-                for (const auto &sub : obsName) {
-                    obs_concat += sub;
-                }
-                const auto m_buffer = gate_matrix.request();
-                std::vector<Kokkos::complex<ParamT>> conv_matrix;
-                if (m_buffer.size) {
-                    const auto m_ptr =
-                        static_cast<const Kokkos::complex<ParamT> *>(
-                            m_buffer.ptr);
-                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                        m_ptr, m_ptr + m_buffer.size};
-                }
-                // Return the real component only & ignore params
-                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                    obs_concat, wires, std::vector<ParamT>{}, conv_matrix);
-            },
-            "Calculate the expectation value of the given observable.")
-        .def(
-            "ExpectationValue",
-            [](StateVectorKokkos<PrecisionT> &sv,
-               const std::vector<std::size_t> &wires,
-               const np_arr_c &gate_matrix) {
-                const auto m_buffer = gate_matrix.request();
-                std::vector<Kokkos::complex<ParamT>> conv_matrix;
-                if (m_buffer.size) {
-                    const auto m_ptr =
-                        static_cast<const Kokkos::complex<ParamT> *>(
-                            m_buffer.ptr);
-                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                        m_ptr, m_ptr + m_buffer.size};
-                }
-                // Return the real component only & ignore params
-                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                    wires, conv_matrix);
-            },
-            "Calculate the expectation value of the given observable.")
-
-        .def(
-            "ExpectationValue",
-            [](StateVectorKokkos<PrecisionT> &sv, const np_arr_c &gate_data,
-               const std::vector<std::size_t> &indices,
-               const std::vector<std::size_t> &index_ptr) {
-                const auto m_buffer = gate_data.request();
-                std::vector<Kokkos::complex<ParamT>> conv_data;
-                if (m_buffer.size) {
-                    const auto m_ptr =
-                        static_cast<const Kokkos::complex<ParamT> *>(
-                            m_buffer.ptr);
-                    conv_data = std::vector<Kokkos::complex<ParamT>>{
-                        m_ptr, m_ptr + m_buffer.size};
-                }
-                // Return the real component only & ignore params
-                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                    conv_data, indices, index_ptr);
-            },
-            "Calculate the expectation value of the given observable.")
-        .def("probs",
-             [](StateVectorKokkos<PrecisionT> &sv,
-                const std::vector<size_t> &wires) {
-                 auto m = MeasuresKokkos<PrecisionT>(sv);
-                 if (wires.empty()) {
-                     return py::array_t<ParamT>(py::cast(m.probs()));
-                 }
-
-                 const bool is_sorted_wires =
-                     std::is_sorted(wires.begin(), wires.end());
-
-                 if (wires.size() == sv.getNumQubits()) {
-                     if (is_sorted_wires)
-                         return py::array_t<ParamT>(py::cast(m.probs()));
-                 }
-                 return py::array_t<ParamT>(py::cast(m.probs(wires)));
-             })
-        .def("GenerateSamples",
-             [](StateVectorKokkos<PrecisionT> &sv, size_t num_wires,
-                size_t num_shots) {
-                 auto &&result =
-                     MeasuresKokkos<PrecisionT>(sv).generate_samples(num_shots);
-
-                 const size_t ndim = 2;
-                 const std::vector<size_t> shape{num_shots, num_wires};
-                 constexpr auto sz = sizeof(size_t);
-                 const std::vector<size_t> strides{sz * num_wires, sz};
-                 // return 2-D NumPy array
-                 return py::array(py::buffer_info(
-                     result.data(), /* data as contiguous array  */
-                     sz,            /* size of one scalar        */
-                     py::format_descriptor<size_t>::format(), /* data type */
-                     ndim,   /* number of dimensions      */
-                     shape,  /* shape of the matrix       */
-                     strides /* strides for each axis     */
-                     ));
-             })
-        .def(
-            "DeviceToHost",
-            [](StateVectorKokkos<PrecisionT> &device_sv, np_arr_c &host_sv) {
-                py::buffer_info numpyArrayInfo = host_sv.request();
-                auto *data_ptr = static_cast<Kokkos::complex<PrecisionT> *>(
-                    numpyArrayInfo.ptr);
-                if (host_sv.size()) {
-                    device_sv.DeviceToHost(data_ptr, host_sv.size());
-                }
-            },
-            "Synchronize data from the GPU device to host.")
-        .def("HostToDevice",
-             py::overload_cast<Kokkos::complex<PrecisionT> *, size_t>(
-                 &StateVectorKokkos<PrecisionT>::HostToDevice),
-             "Synchronize data from the host device to GPU.")
-        .def(
-            "HostToDevice",
-            [](StateVectorKokkos<PrecisionT> &device_sv,
-               const np_arr_c &host_sv) {
-                const py::buffer_info numpyArrayInfo = host_sv.request();
-                auto *data_ptr = static_cast<Kokkos::complex<PrecisionT> *>(
-                    numpyArrayInfo.ptr);
-                const auto length =
-                    static_cast<size_t>(numpyArrayInfo.shape[0]);
-                if (length) {
-                    device_sv.HostToDevice(data_ptr, length);
-                }
-            },
-            "Synchronize data from the host device to GPU.")
-        .def("numQubits", &StateVectorKokkos<PrecisionT>::getNumQubits)
-        .def("dataLength", &StateVectorKokkos<PrecisionT>::getLength)
-        .def("resetKokkos", &StateVectorKokkos<PrecisionT>::resetStateVector);
-
-    //***********************************************************************//
-    //                              Observable
-    //***********************************************************************//
-
-    class_name = "ObservableKokkos_C" + bitsize;
-    py::class_<ObservableKokkos<PrecisionT>,
-               std::shared_ptr<ObservableKokkos<PrecisionT>>>(
-        m, class_name.c_str(), py::module_local());
-
-    class_name = "NamedObsKokkos_C" + bitsize;
-    py::class_<NamedObsKokkos<PrecisionT>,
-               std::shared_ptr<NamedObsKokkos<PrecisionT>>,
-               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                             py::module_local())
-        .def(py::init(
-            [](const std::string &name, const std::vector<size_t> &wires) {
-                return NamedObsKokkos<PrecisionT>(name, wires);
-            }))
-        .def("__repr__", &NamedObsKokkos<PrecisionT>::getObsName)
-        .def("get_wires", &NamedObsKokkos<PrecisionT>::getWires,
-             "Get wires of observables")
-        .def(
-            "__eq__",
-            [](const NamedObsKokkos<PrecisionT> &self,
-               py::handle other) -> bool {
-                if (!py::isinstance<NamedObsKokkos<PrecisionT>>(other)) {
-                    return false;
-                }
-                auto other_cast = other.cast<NamedObsKokkos<PrecisionT>>();
-                return self == other_cast;
-            },
-            "Compare two observables");
-
-    class_name = "HermitianObsKokkos_C" + bitsize;
-    py::class_<HermitianObsKokkos<PrecisionT>,
-               std::shared_ptr<HermitianObsKokkos<PrecisionT>>,
-               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                             py::module_local())
-        .def(py::init([](const np_arr_c &matrix,
-                         const std::vector<size_t> &wires) {
+  class_name = "HermitianObsKokkos_C" + bitsize;
+  py::class_<HermitianObsKokkos<PrecisionT>,
+             std::shared_ptr<HermitianObsKokkos<PrecisionT>>,
+             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                           py::module_local())
+      .def(py::init(
+          [](const np_arr_c &matrix, const std::vector<size_t> &wires) {
             const auto m_buffer = matrix.request();
             std::vector<std::complex<ParamT>> conv_matrix;
             if (m_buffer.size) {
-                const auto m_ptr =
-                    static_cast<const std::complex<PrecisionT> *>(m_buffer.ptr);
-                conv_matrix = std::vector<std::complex<PrecisionT>>{
-                    m_ptr, m_ptr + m_buffer.size};
+              const auto m_ptr =
+                  static_cast<const std::complex<PrecisionT> *>(m_buffer.ptr);
+              conv_matrix = std::vector<std::complex<PrecisionT>>{
+                  m_ptr, m_ptr + m_buffer.size};
             }
             return HermitianObsKokkos<PrecisionT>(conv_matrix, wires);
-        }))
-        .def("__repr__", &HermitianObsKokkos<PrecisionT>::getObsName)
-        .def("get_wires", &HermitianObsKokkos<PrecisionT>::getWires,
-             "Get wires of observables")
-        .def(
-            "__eq__",
-            [](const HermitianObsKokkos<PrecisionT> &self,
-               py::handle other) -> bool {
-                if (!py::isinstance<HermitianObsKokkos<PrecisionT>>(other)) {
-                    return false;
-                }
-                auto other_cast = other.cast<HermitianObsKokkos<PrecisionT>>();
-                return self == other_cast;
-            },
-            "Compare two observables");
-
-    class_name = "TensorProdObsKokkos_C" + bitsize;
-    py::class_<TensorProdObsKokkos<PrecisionT>,
-               std::shared_ptr<TensorProdObsKokkos<PrecisionT>>,
-               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                             py::module_local())
-        .def(py::init(
-            [](const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
-                   &obs) { return TensorProdObsKokkos<PrecisionT>(obs); }))
-        .def("__repr__", &TensorProdObsKokkos<PrecisionT>::getObsName)
-        .def("get_wires", &TensorProdObsKokkos<PrecisionT>::getWires,
-             "Get wires of observables")
-        .def(
-            "__eq__",
-            [](const TensorProdObsKokkos<PrecisionT> &self,
-               py::handle other) -> bool {
-                if (!py::isinstance<TensorProdObsKokkos<PrecisionT>>(other)) {
-                    return false;
-                }
-                auto other_cast = other.cast<TensorProdObsKokkos<PrecisionT>>();
-                return self == other_cast;
-            },
-            "Compare two observables");
-
-    class_name = "HamiltonianKokkos_C" + bitsize;
-    using ObsPtr = std::shared_ptr<ObservableKokkos<PrecisionT>>;
-    py::class_<HamiltonianKokkos<PrecisionT>,
-               std::shared_ptr<HamiltonianKokkos<PrecisionT>>,
-               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                             py::module_local())
-        .def(py::init(
-            [](const np_arr_r &coeffs, const std::vector<ObsPtr> &obs) {
-                auto buffer = coeffs.request();
-                const auto ptr = static_cast<const ParamT *>(buffer.ptr);
-                return HamiltonianKokkos<PrecisionT>{
-                    std::vector(ptr, ptr + buffer.size), obs};
-            }))
-        .def("__repr__", &HamiltonianKokkos<PrecisionT>::getObsName)
-        .def("get_wires", &HamiltonianKokkos<PrecisionT>::getWires,
-             "Get wires of observables")
-        .def(
-            "__eq__",
-            [](const HamiltonianKokkos<PrecisionT> &self,
-               py::handle other) -> bool {
-                if (!py::isinstance<HamiltonianKokkos<PrecisionT>>(other)) {
-                    return false;
-                }
-                auto other_cast = other.cast<HamiltonianKokkos<PrecisionT>>();
-                return self == other_cast;
-            },
-            "Compare two observables");
-
-    class_name = "SparseHamiltonianKokkos_C" + bitsize;
-    py::class_<SparseHamiltonianKokkos<PrecisionT>,
-               std::shared_ptr<SparseHamiltonianKokkos<PrecisionT>>,
-               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                             py::module_local())
-        .def(py::init([](const np_arr_c &data,
-                         const std::vector<std::size_t> &indices,
-                         const std::vector<std::size_t> &indptr,
-                         const std::vector<std::size_t> &wires) {
-            const py::buffer_info buffer_data = data.request();
-            const auto *data_ptr =
-                static_cast<std::complex<PrecisionT> *>(buffer_data.ptr);
-
-            return SparseHamiltonianKokkos<PrecisionT>{
-                std::vector<std::complex<PrecisionT>>(
-                    {data_ptr, data_ptr + data.size()}),
-                indices, indptr, wires};
-        }))
-        .def("__repr__", &SparseHamiltonianKokkos<PrecisionT>::getObsName)
-        .def("get_wires", &SparseHamiltonianKokkos<PrecisionT>::getWires,
-             "Get wires of observables")
-        .def(
-            "__eq__",
-            [](const SparseHamiltonianKokkos<PrecisionT> &self,
-               py::handle other) -> bool {
-                if (!py::isinstance<SparseHamiltonianKokkos<PrecisionT>>(
-                        other)) {
-                    return false;
-                }
-                auto other_cast =
-                    other.cast<SparseHamiltonianKokkos<PrecisionT>>();
-                return self == other_cast;
-            },
-            "Compare two observables");
-
-    //***********************************************************************//
-    //                              Operations
-    //***********************************************************************//
-    class_name = "OpsStructKokkos_C" + bitsize;
-    py::class_<OpsData<PrecisionT>>(m, class_name.c_str(), py::module_local())
-        .def(py::init<
-             const std::vector<std::string> &,
-             const std::vector<std::vector<ParamT>> &,
-             const std::vector<std::vector<size_t>> &,
-             const std::vector<bool> &,
-             const std::vector<std::vector<std::complex<PrecisionT>>> &>())
-        .def("__repr__", [](const OpsData<PrecisionT> &ops) {
-            using namespace Pennylane::Util;
-            std::ostringstream ops_stream;
-            for (size_t op = 0; op < ops.getSize(); op++) {
-                ops_stream << "{'name': " << ops.getOpsName()[op];
-                ops_stream << ", 'params': " << ops.getOpsParams()[op];
-                ops_stream << ", 'inv': " << ops.getOpsInverses()[op];
-                ops_stream << "}";
-                if (op < ops.getSize() - 1) {
-                    ops_stream << ",";
-                }
+          }))
+      .def("__repr__", &HermitianObsKokkos<PrecisionT>::getObsName)
+      .def("get_wires", &HermitianObsKokkos<PrecisionT>::getWires,
+           "Get wires of observables")
+      .def(
+          "__eq__",
+          [](const HermitianObsKokkos<PrecisionT> &self,
+             py::handle other) -> bool {
+            if (!py::isinstance<HermitianObsKokkos<PrecisionT>>(other)) {
+              return false;
             }
-            return "Operations: [" + ops_stream.str() + "]";
-        });
+            auto other_cast = other.cast<HermitianObsKokkos<PrecisionT>>();
+            return self == other_cast;
+          },
+          "Compare two observables");
 
-    //***********************************************************************//
-    //                              Adj Jac
-    //***********************************************************************//
+  class_name = "TensorProdObsKokkos_C" + bitsize;
+  py::class_<TensorProdObsKokkos<PrecisionT>,
+             std::shared_ptr<TensorProdObsKokkos<PrecisionT>>,
+             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                           py::module_local())
+      .def(py::init(
+          [](const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
+                 &obs) { return TensorProdObsKokkos<PrecisionT>(obs); }))
+      .def("__repr__", &TensorProdObsKokkos<PrecisionT>::getObsName)
+      .def("get_wires", &TensorProdObsKokkos<PrecisionT>::getWires,
+           "Get wires of observables")
+      .def(
+          "__eq__",
+          [](const TensorProdObsKokkos<PrecisionT> &self,
+             py::handle other) -> bool {
+            if (!py::isinstance<TensorProdObsKokkos<PrecisionT>>(other)) {
+              return false;
+            }
+            auto other_cast = other.cast<TensorProdObsKokkos<PrecisionT>>();
+            return self == other_cast;
+          },
+          "Compare two observables");
 
-    class_name = "AdjointJacobianKokkos_C" + bitsize;
-    py::class_<AdjointJacobianKokkos<PrecisionT>>(m, class_name.c_str(),
-                                                  py::module_local())
-        .def(py::init<>())
-        .def("create_ops_list",
-             [](AdjointJacobianKokkos<PrecisionT> &adj,
-                const std::vector<std::string> &ops_name,
-                const std::vector<np_arr_r> &ops_params,
-                const std::vector<std::vector<size_t>> &ops_wires,
-                const std::vector<bool> &ops_inverses,
-                const std::vector<np_arr_c> &ops_matrices) {
-                 std::vector<std::vector<PrecisionT>> conv_params(
-                     ops_params.size());
-                 std::vector<std::vector<std::complex<PrecisionT>>>
-                     conv_matrices(ops_matrices.size());
-                 static_cast<void>(adj);
-                 for (size_t op = 0; op < ops_name.size(); op++) {
-                     const auto p_buffer = ops_params[op].request();
-                     const auto m_buffer = ops_matrices[op].request();
-                     if (p_buffer.size) {
-                         const auto *const p_ptr =
-                             static_cast<const ParamT *>(p_buffer.ptr);
-                         conv_params[op] =
-                             std::vector<ParamT>{p_ptr, p_ptr + p_buffer.size};
-                     }
+  class_name = "HamiltonianKokkos_C" + bitsize;
+  using ObsPtr = std::shared_ptr<ObservableKokkos<PrecisionT>>;
+  py::class_<HamiltonianKokkos<PrecisionT>,
+             std::shared_ptr<HamiltonianKokkos<PrecisionT>>,
+             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                           py::module_local())
+      .def(py::init([](const np_arr_r &coeffs, const std::vector<ObsPtr> &obs) {
+        auto buffer = coeffs.request();
+        const auto ptr = static_cast<const ParamT *>(buffer.ptr);
+        return HamiltonianKokkos<PrecisionT>{
+            std::vector(ptr, ptr + buffer.size), obs};
+      }))
+      .def("__repr__", &HamiltonianKokkos<PrecisionT>::getObsName)
+      .def("get_wires", &HamiltonianKokkos<PrecisionT>::getWires,
+           "Get wires of observables")
+      .def(
+          "__eq__",
+          [](const HamiltonianKokkos<PrecisionT> &self,
+             py::handle other) -> bool {
+            if (!py::isinstance<HamiltonianKokkos<PrecisionT>>(other)) {
+              return false;
+            }
+            auto other_cast = other.cast<HamiltonianKokkos<PrecisionT>>();
+            return self == other_cast;
+          },
+          "Compare two observables");
 
-                     if (m_buffer.size) {
-                         const auto m_ptr =
-                             static_cast<const std::complex<ParamT> *>(
-                                 m_buffer.ptr);
-                         conv_matrices[op] = std::vector<std::complex<ParamT>>{
-                             m_ptr, m_ptr + m_buffer.size};
-                     }
-                 }
+  class_name = "SparseHamiltonianKokkos_C" + bitsize;
+  py::class_<SparseHamiltonianKokkos<PrecisionT>,
+             std::shared_ptr<SparseHamiltonianKokkos<PrecisionT>>,
+             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                           py::module_local())
+      .def(py::init([](const np_arr_c &data,
+                       const std::vector<std::size_t> &indices,
+                       const std::vector<std::size_t> &indptr,
+                       const std::vector<std::size_t> &wires) {
+        const py::buffer_info buffer_data = data.request();
+        const auto *data_ptr =
+            static_cast<std::complex<PrecisionT> *>(buffer_data.ptr);
 
-                 return OpsData<PrecisionT>{ops_name, conv_params, ops_wires,
-                                            ops_inverses, conv_matrices};
-             })
-        .def("adjoint_jacobian",
-             &AdjointJacobianKokkos<PrecisionT>::adjointJacobian)
-        .def("adjoint_jacobian",
-             [](AdjointJacobianKokkos<PrecisionT> &adj,
-                const StateVectorKokkos<PrecisionT> &sv,
-                const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
-                    &observables,
-                const OpsData<PrecisionT> &operations,
-                const std::vector<size_t> &trainableParams) {
-                 std::vector<std::vector<PrecisionT>> jac(
-                     observables.size(),
-                     std::vector<PrecisionT>(trainableParams.size(), 0));
-                 adj.adjointJacobian(sv, jac, observables, operations,
-                                     trainableParams, false);
-                 return py::array_t<ParamT>(py::cast(jac));
-             });
+        return SparseHamiltonianKokkos<PrecisionT>{
+            std::vector<std::complex<PrecisionT>>(
+                {data_ptr, data_ptr + data.size()}),
+            indices, indptr, wires};
+      }))
+      .def("__repr__", &SparseHamiltonianKokkos<PrecisionT>::getObsName)
+      .def("get_wires", &SparseHamiltonianKokkos<PrecisionT>::getWires,
+           "Get wires of observables")
+      .def(
+          "__eq__",
+          [](const SparseHamiltonianKokkos<PrecisionT> &self,
+             py::handle other) -> bool {
+            if (!py::isinstance<SparseHamiltonianKokkos<PrecisionT>>(other)) {
+              return false;
+            }
+            auto other_cast = other.cast<SparseHamiltonianKokkos<PrecisionT>>();
+            return self == other_cast;
+          },
+          "Compare two observables");
+
+  //***********************************************************************//
+  //                              Operations
+  //***********************************************************************//
+  class_name = "OpsStructKokkos_C" + bitsize;
+  py::class_<OpsData<PrecisionT>>(m, class_name.c_str(), py::module_local())
+      .def(py::init<
+           const std::vector<std::string> &,
+           const std::vector<std::vector<ParamT>> &,
+           const std::vector<std::vector<size_t>> &, const std::vector<bool> &,
+           const std::vector<std::vector<std::complex<PrecisionT>>> &>())
+      .def("__repr__", [](const OpsData<PrecisionT> &ops) {
+        using namespace Pennylane::Util;
+        std::ostringstream ops_stream;
+        for (size_t op = 0; op < ops.getSize(); op++) {
+          ops_stream << "{'name': " << ops.getOpsName()[op];
+          ops_stream << ", 'params': " << ops.getOpsParams()[op];
+          ops_stream << ", 'inv': " << ops.getOpsInverses()[op];
+          ops_stream << "}";
+          if (op < ops.getSize() - 1) {
+            ops_stream << ",";
+          }
+        }
+        return "Operations: [" + ops_stream.str() + "]";
+      });
+
+  //***********************************************************************//
+  //                              Adj Jac
+  //***********************************************************************//
+
+  class_name = "AdjointJacobianKokkos_C" + bitsize;
+  py::class_<AdjointJacobianKokkos<PrecisionT>>(m, class_name.c_str(),
+                                                py::module_local())
+      .def(py::init<>())
+      .def("create_ops_list",
+           [](AdjointJacobianKokkos<PrecisionT> &adj,
+              const std::vector<std::string> &ops_name,
+              const std::vector<np_arr_r> &ops_params,
+              const std::vector<std::vector<size_t>> &ops_wires,
+              const std::vector<bool> &ops_inverses,
+              const std::vector<np_arr_c> &ops_matrices) {
+             std::vector<std::vector<PrecisionT>> conv_params(
+                 ops_params.size());
+             std::vector<std::vector<std::complex<PrecisionT>>> conv_matrices(
+                 ops_matrices.size());
+             static_cast<void>(adj);
+             for (size_t op = 0; op < ops_name.size(); op++) {
+               const auto p_buffer = ops_params[op].request();
+               const auto m_buffer = ops_matrices[op].request();
+               if (p_buffer.size) {
+                 const auto *const p_ptr =
+                     static_cast<const ParamT *>(p_buffer.ptr);
+                 conv_params[op] =
+                     std::vector<ParamT>{p_ptr, p_ptr + p_buffer.size};
+               }
+
+               if (m_buffer.size) {
+                 const auto m_ptr =
+                     static_cast<const std::complex<ParamT> *>(m_buffer.ptr);
+                 conv_matrices[op] = std::vector<std::complex<ParamT>>{
+                     m_ptr, m_ptr + m_buffer.size};
+               }
+             }
+
+             return OpsData<PrecisionT>{ops_name, conv_params, ops_wires,
+                                        ops_inverses, conv_matrices};
+           })
+      .def("adjoint_jacobian",
+           &AdjointJacobianKokkos<PrecisionT>::adjointJacobian)
+      .def("adjoint_jacobian",
+           [](AdjointJacobianKokkos<PrecisionT> &adj,
+              const StateVectorKokkos<PrecisionT> &sv,
+              const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
+                  &observables,
+              const OpsData<PrecisionT> &operations,
+              const std::vector<size_t> &trainableParams) {
+             std::vector<std::vector<PrecisionT>> jac(
+                 observables.size(),
+                 std::vector<PrecisionT>(trainableParams.size(), 0));
+             adj.adjointJacobian(sv, jac, observables, operations,
+                                 trainableParams, false);
+             return py::array_t<ParamT>(py::cast(jac));
+           });
 }
 
 // Necessary to avoid mangled names when manually building module
@@ -830,35 +817,114 @@ extern "C" {
 PYBIND11_MODULE(lightning_kokkos_qubit_ops, // NOLINT: No control over
                                             // Pybind internals
                 m) {
-    // Suppress doxygen autogenerated signatures
+  // Suppress doxygen autogenerated signatures
 
-    py::options options;
-    options.disable_function_signatures();
-    py::register_exception<LightningException>(m, "PLException");
+  py::options options;
+  options.disable_function_signatures();
+  py::register_exception<LightningException>(m, "PLException");
 
-    StateVectorKokkos_class_bindings<float, float>(m);
-    StateVectorKokkos_class_bindings<double, double>(m);
+  StateVectorKokkos_class_bindings<float, float>(m);
+  StateVectorKokkos_class_bindings<double, double>(m);
 
-    m.def("kokkos_start", []() { Kokkos::initialize(); });
-    m.def("kokkos_end", []() { Kokkos::finalize(); });
-    m.def("kokkos_config_info", &getConfig, "Kokkos configurations query.");
+  m.def("kokkos_start", []() { Kokkos::initialize(); });
+  m.def("kokkos_end", []() { Kokkos::finalize(); });
+  m.def("kokkos_config_info", &getConfig, "Kokkos configurations query.");
 
-    py::class_<Kokkos::InitArguments>(m, "InitArguments")
-        .def(py::init<>())
-        .def(py::init<const int &>())
-        .def_readwrite("num_threads", &Kokkos::InitArguments::num_threads)
-        .def_readwrite("num_numa", &Kokkos::InitArguments::num_numa)
-        .def_readwrite("device_id", &Kokkos::InitArguments::device_id)
-        .def_readwrite("ndevices", &Kokkos::InitArguments::ndevices)
-        .def_readwrite("skip_device", &Kokkos::InitArguments::skip_device)
-        .def_readwrite("disable_warnings",
-                       &Kokkos::InitArguments::disable_warnings)
-        .def("__repr__", [](const Kokkos::InitArguments &args) {
-            using namespace Pennylane::Util;
-            std::ostringstream args_stream;
-            args_stream << args;
-            return args_stream.str();
-        });
+  py::class_<Kokkos::InitializationSettings>(m, "InitializationSettings")
+      .def(py::init<>())
+      .def("get_num_threads", &Kokkos::InitializationSettings::get_num_threads,
+           "Number of threads to use with the host parallel backend. Must be "
+           "greater than zero.")
+      .def("get_device_id", &Kokkos::InitializationSettings::get_device_id,
+           "Device to use with the device parallel backend. Valid IDs are "
+           "zero to number of GPU(s) available for execution minus one.")
+      .def("get_map_device_id_by",
+           &Kokkos::InitializationSettings::get_map_device_id_by,
+           "Strategy to select a device automatically from the GPUs available "
+           "for execution. Must be either mpi_rank"
+           "for round-robin assignment based on the local MPI rank or random.")
+      .def("get_disable_warnings",
+           &Kokkos::InitializationSettings::get_disable_warnings,
+           "Whether to disable warning messages.")
+      .def("get_print_configuration",
+           &Kokkos::InitializationSettings::get_print_configuration,
+           "Whether to print the configuration after initialization.")
+      .def("get_tune_internals",
+           &Kokkos::InitializationSettings::get_tune_internals,
+           "Whether to allow autotuning internals instead of using "
+           "heuristics.")
+      .def("get_tools_libs", &Kokkos::InitializationSettings::get_tools_libs,
+           "Which tool dynamic library to load. Must either be the full path "
+           "to library or the name of library if the path is present in the "
+           "runtime library search path (e.g. LD_LIBRARY_PATH)")
+      .def("get_tools_help", &Kokkos::InitializationSettings::get_tools_help,
+           "Query the loaded tool for its command-line options support.")
+      .def("get_tools_args", &Kokkos::InitializationSettings::get_tools_args,
+           "Options to pass to the loaded tool as command-line arguments.")
+      .def("has_num_threads", &Kokkos::InitializationSettings::has_num_threads,
+           "Number of threads to use with the host parallel backend. Must be "
+           "greater than zero.")
+      .def("has_device_id", &Kokkos::InitializationSettings::has_device_id,
+           "Device to use with the device parallel backend. Valid IDs are zero "
+           "to number of GPU(s) available for execution minus one.")
+      .def("has_map_device_id_by",
+           &Kokkos::InitializationSettings::has_map_device_id_by,
+           "Strategy to select a device automatically from the GPUs available "
+           "for execution. Must be either mpi_rank"
+           "for round-robin assignment based on the local MPI rank or random.")
+      .def("has_disable_warnings",
+           &Kokkos::InitializationSettings::has_disable_warnings,
+           "Whether to disable warning messages.")
+      .def("has_print_configuration",
+           &Kokkos::InitializationSettings::has_print_configuration,
+           "Whether to print the configuration after initialization.")
+      .def("has_tune_internals",
+           &Kokkos::InitializationSettings::has_tune_internals,
+           "Whether to allow autotuning internals instead of using heuristics.")
+      .def(
+          "has_tools_libs", &Kokkos::InitializationSettings::has_tools_libs,
+          "Which tool dynamic library to load. Must either be the full path to "
+          "library or the name of library if the path is present in the "
+          "runtime library search path (e.g. LD_LIBRARY_PATH)")
+      .def("has_tools_help", &Kokkos::InitializationSettings::has_tools_help,
+           "Query the loaded tool for its command-line options support.")
+      .def("has_tools_args", &Kokkos::InitializationSettings::has_tools_args,
+           "Options to pass to the loaded tool as command-line arguments.")
+      .def("set_num_threads", &Kokkos::InitializationSettings::set_num_threads,
+           "Number of threads to use with the host parallel backend. Must be "
+           "greater than zero.")
+      .def("set_device_id", &Kokkos::InitializationSettings::set_device_id,
+           "Device to use with the device parallel backend. Valid IDs are "
+           "zero to number of GPU(s) available for execution minus one.")
+      .def("set_map_device_id_by",
+           &Kokkos::InitializationSettings::set_map_device_id_by,
+           "Strategy to select a device automatically from the GPUs available "
+           "for execution. Must be either mpi_rank"
+           "for round-robin assignment based on the local MPI rank or random.")
+      .def("set_disable_warnings",
+           &Kokkos::InitializationSettings::set_disable_warnings,
+           "Whether to disable warning messages.")
+      .def("set_print_configuration",
+           &Kokkos::InitializationSettings::set_print_configuration,
+           "Whether to print the configuration after initialization.")
+      .def("set_tune_internals",
+           &Kokkos::InitializationSettings::set_tune_internals,
+           "Whether to allow autotuning internals instead of using "
+           "heuristics.")
+      .def("set_tools_libs", &Kokkos::InitializationSettings::set_tools_libs,
+           "Which tool dynamic library to load. Must either be the full path "
+           "to library or the name of library if the path is present in the "
+           "runtime library search path (e.g. LD_LIBRARY_PATH)")
+      .def("set_tools_help", &Kokkos::InitializationSettings::set_tools_help,
+           "Query the loaded tool for its command-line options support.")
+      .def("set_tools_args", &Kokkos::InitializationSettings::set_tools_args,
+           "Options to pass to the loaded tool as command-line arguments.")
+      .def("__repr__", [](const Kokkos::InitializationSettings &args) {
+        using namespace Pennylane::Util;
+        std::ostringstream args_stream;
+        args_stream << args;
+        return args_stream.str();
+      });
 }
 }
 

--- a/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
@@ -50,762 +50,775 @@ namespace py = pybind11;
 template <class PrecisionT, class ParamT>
 void StateVectorKokkos_class_bindings(py::module &m) {
 
-  using np_arr_r =
-      py::array_t<ParamT, py::array::c_style | py::array::forcecast>;
-  using np_arr_c = py::array_t<std::complex<ParamT>,
-                               py::array::c_style | py::array::forcecast>;
+    using np_arr_r =
+        py::array_t<ParamT, py::array::c_style | py::array::forcecast>;
+    using np_arr_c = py::array_t<std::complex<ParamT>,
+                                 py::array::c_style | py::array::forcecast>;
 
-  // Enable module name to be based on size of complex datatype
-  const std::string bitsize =
-      std::to_string(sizeof(std::complex<PrecisionT>) * 8);
-  std::string class_name = "LightningKokkos_C" + bitsize;
+    // Enable module name to be based on size of complex datatype
+    const std::string bitsize =
+        std::to_string(sizeof(std::complex<PrecisionT>) * 8);
+    std::string class_name = "LightningKokkos_C" + bitsize;
 
-  py::class_<StateVectorKokkos<PrecisionT>>(m, class_name.c_str())
-      .def(py::init([](std::size_t num_qubits) {
-        return new StateVectorKokkos<PrecisionT>(num_qubits);
-      }))
-      .def(py::init([](std::size_t num_qubits,
-                       const Kokkos::InitializationSettings &kokkos_args) {
-        return new StateVectorKokkos<PrecisionT>(num_qubits, kokkos_args);
-      }))
-      .def(py::init([](const np_arr_c &arr) {
-        py::buffer_info numpyArrayInfo = arr.request();
-        auto *data_ptr =
-            static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-        return new StateVectorKokkos<PrecisionT>(
-            data_ptr, static_cast<std::size_t>(arr.size()));
-      }))
-      .def(py::init([](const np_arr_c &arr,
-                       const Kokkos::InitializationSettings &kokkos_args) {
-        py::buffer_info numpyArrayInfo = arr.request();
-        auto *data_ptr =
-            static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-        return new StateVectorKokkos<PrecisionT>(
-            data_ptr, static_cast<std::size_t>(arr.size()), kokkos_args);
-      }))
-      .def(
-          "setBasisState",
-          [](StateVectorKokkos<PrecisionT> &sv, const size_t index) {
-            sv.setBasisState(index);
-          },
-          "Create Basis State on Device.")
-      .def(
-          "setStateVector",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &indices, const np_arr_c &state) {
-            const auto buffer = state.request();
-            std::vector<Kokkos::complex<ParamT>> state_kok;
-            if (buffer.size) {
-              const auto ptr =
-                  static_cast<const Kokkos::complex<ParamT> *>(buffer.ptr);
-              state_kok =
-                  std::vector<Kokkos::complex<ParamT>>{ptr, ptr + buffer.size};
-            }
-            sv.setStateVector(indices, state_kok);
-          },
-          "Set State Vector on device with values and their corresponding "
-          "indices for the state vector on device")
-      .def(
-          "Identity",
-          []([[maybe_unused]] StateVectorKokkos<PrecisionT> &sv,
-             [[maybe_unused]] const std::vector<std::size_t> &wires,
-             [[maybe_unused]] bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {},
-          "Apply the Identity gate.")
-      .def(
-          "PauliX",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyPauliX(wires, adjoint);
-          },
-          "Apply the PauliX gate.")
-
-      .def(
-          "PauliY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyPauliY(wires, adjoint);
-          },
-          "Apply the PauliY gate.")
-
-      .def(
-          "PauliZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyPauliZ(wires, adjoint);
-          },
-          "Apply the PauliZ gate.")
-
-      .def(
-          "Hadamard",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyHadamard(wires, adjoint);
-          },
-          "Apply the Hadamard gate.")
-
-      .def(
-          "S",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyS(wires, adjoint);
-          },
-          "Apply the S gate.")
-
-      .def(
-          "T",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyT(wires, adjoint);
-          },
-          "Apply the T gate.")
-
-      .def(
-          "CNOT",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyCNOT(wires, adjoint);
-          },
-          "Apply the CNOT gate.")
-
-      .def(
-          "SWAP",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applySWAP(wires, adjoint);
-          },
-          "Apply the SWAP gate.")
-
-      .def(
-          "CSWAP",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyCSWAP(wires, adjoint);
-          },
-          "Apply the CSWAP gate.")
-
-      .def(
-          "Toffoli",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyToffoli(wires, adjoint);
-          },
-          "Apply the Toffoli gate.")
-
-      .def(
-          "CY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyCY(wires, adjoint);
-          },
-          "Apply the CY gate.")
-
-      .def(
-          "CZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             [[maybe_unused]] const std::vector<ParamT> &params) {
-            sv.applyCZ(wires, adjoint);
-          },
-          "Apply the CZ gate.")
-
-      .def(
-          "PhaseShift",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyPhaseShift(wires, adjoint, params);
-          },
-          "Apply the PhaseShift gate.")
-
-      .def("apply",
-           py::overload_cast<
-               const vector<string> &, const vector<vector<std::size_t>> &,
-               const vector<bool> &, const vector<vector<PrecisionT>> &>(
-               &StateVectorKokkos<PrecisionT>::applyOperation))
-
-      .def("apply", py::overload_cast<const vector<string> &,
-                                      const vector<vector<std::size_t>> &,
-                                      const vector<bool> &>(
-                        &StateVectorKokkos<PrecisionT>::applyOperation))
-      .def(
-          "apply",
-          [](StateVectorKokkos<PrecisionT> &sv, const std::string &str,
-             const vector<size_t> &wires, bool inv,
-             [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
-             [[maybe_unused]] const np_arr_c &gate_matrix) {
-            const auto m_buffer = gate_matrix.request();
-            std::vector<Kokkos::complex<ParamT>> conv_matrix;
-            if (m_buffer.size) {
-              const auto m_ptr =
-                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
-              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                  m_ptr, m_ptr + m_buffer.size};
-            }
-            sv.applyOperation_std(str, wires, inv, std::vector<ParamT>{},
-                                  conv_matrix);
-          },
-          "Apply operation via the gate matrix")
-      .def("applyGenerator",
-           py::overload_cast<const std::string &, const std::vector<size_t> &,
-                             bool, const vector<PrecisionT> &>(
-               &StateVectorKokkos<PrecisionT>::applyGenerator))
-      .def(
-          "ControlledPhaseShift",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyControlledPhaseShift(wires, adjoint, params);
-          },
-          "Apply the ControlledPhaseShift gate.")
-
-      .def(
-          "RX",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyRX(wires, adjoint, params);
-          },
-          "Apply the RX gate.")
-
-      .def(
-          "RY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyRY(wires, adjoint, params);
-          },
-          "Apply the RY gate.")
-
-      .def(
-          "RZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyRZ(wires, adjoint, params);
-          },
-          "Apply the RZ gate.")
-
-      .def(
-          "Rot",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyRot(wires, adjoint, params);
-          },
-          "Apply the Rot gate.")
-
-      .def(
-          "CRX",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyCRX(wires, adjoint, params);
-          },
-          "Apply the CRX gate.")
-
-      .def(
-          "CRY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyCRY(wires, adjoint, params);
-          },
-          "Apply the CRY gate.")
-
-      .def(
-          "CRZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyCRZ(wires, adjoint, params);
-          },
-          "Apply the CRZ gate.")
-
-      .def(
-          "CRot",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyCRot(wires, adjoint, params);
-          },
-          "Apply the CRot gate.")
-      .def(
-          "IsingXX",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyIsingXX(wires, adjoint, params);
-          },
-          "Apply the IsingXX gate.")
-      .def(
-          "IsingXY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            sv.applyIsingXY(wires, adjoint, params);
-          },
-          "Apply the IsingXY gate.")
-      .def(
-          "IsingYY",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyIsingYY(wires, adjoint, params);
-          },
-          "Apply the IsingYY gate.")
-      .def(
-          "IsingZZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyIsingZZ(wires, adjoint, params);
-          },
-          "Apply the IsingZZ gate.")
-      .def(
-          "MultiRZ",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyMultiRZ(wires, adjoint, params);
-          },
-          "Apply the MultiRZ gate.")
-      .def(
-          "SingleExcitation",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applySingleExcitation(wires, adjoint, params);
-          },
-          "Apply the SingleExcitation gate.")
-      .def(
-          "SingleExcitationMinus",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applySingleExcitationMinus(wires, adjoint, params);
-          },
-          "Apply the SingleExcitationMinus gate.")
-      .def(
-          "SingleExcitationPlus",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applySingleExcitationPlus(wires, adjoint, params);
-          },
-          "Apply the SingleExcitationPlus gate.")
-      .def(
-          "DoubleExcitation",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyDoubleExcitation(wires, adjoint, params);
-          },
-          "Apply the DoubleExcitation gate.")
-      .def(
-          "DoubleExcitationMinus",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyDoubleExcitationMinus(wires, adjoint, params);
-          },
-          "Apply the DoubleExcitationMinus gate.")
-      .def(
-          "DoubleExcitationPlus",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires, bool adjoint,
-             const std::vector<ParamT> &params) {
-            return sv.applyDoubleExcitationPlus(wires, adjoint, params);
-          },
-          "Apply the DoubleExcitationPlus gate.")
-      .def(
-          "ExpectationValue",
-          [](StateVectorKokkos<PrecisionT> &sv, const std::string &obsName,
-             const std::vector<std::size_t> &wires,
-             [[maybe_unused]] const std::vector<ParamT> &params,
-             [[maybe_unused]] const np_arr_c &gate_matrix) {
-            const auto m_buffer = gate_matrix.request();
-            std::vector<Kokkos::complex<ParamT>> conv_matrix;
-            if (m_buffer.size) {
-              auto m_ptr = static_cast<Kokkos::complex<ParamT> *>(m_buffer.ptr);
-              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                  m_ptr, m_ptr + m_buffer.size};
-            }
-            // Return the real component only
-            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                obsName, wires, params, conv_matrix);
-          },
-          "Calculate the expectation value of the given observable.")
-      .def(
-          "ExpectationValue",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::string> &obsName,
-             const std::vector<std::size_t> &wires,
-             [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
-             [[maybe_unused]] const np_arr_c &gate_matrix) {
-            std::string obs_concat{"#"};
-            for (const auto &sub : obsName) {
-              obs_concat += sub;
-            }
-            const auto m_buffer = gate_matrix.request();
-            std::vector<Kokkos::complex<ParamT>> conv_matrix;
-            if (m_buffer.size) {
-              const auto m_ptr =
-                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
-              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                  m_ptr, m_ptr + m_buffer.size};
-            }
-            // Return the real component only & ignore params
-            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                obs_concat, wires, std::vector<ParamT>{}, conv_matrix);
-          },
-          "Calculate the expectation value of the given observable.")
-      .def(
-          "ExpectationValue",
-          [](StateVectorKokkos<PrecisionT> &sv,
-             const std::vector<std::size_t> &wires,
-             const np_arr_c &gate_matrix) {
-            const auto m_buffer = gate_matrix.request();
-            std::vector<Kokkos::complex<ParamT>> conv_matrix;
-            if (m_buffer.size) {
-              const auto m_ptr =
-                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
-              conv_matrix = std::vector<Kokkos::complex<ParamT>>{
-                  m_ptr, m_ptr + m_buffer.size};
-            }
-            // Return the real component only & ignore params
-            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                wires, conv_matrix);
-          },
-          "Calculate the expectation value of the given observable.")
-
-      .def(
-          "ExpectationValue",
-          [](StateVectorKokkos<PrecisionT> &sv, const np_arr_c &gate_data,
-             const std::vector<std::size_t> &indices,
-             const std::vector<std::size_t> &index_ptr) {
-            const auto m_buffer = gate_data.request();
-            std::vector<Kokkos::complex<ParamT>> conv_data;
-            if (m_buffer.size) {
-              const auto m_ptr =
-                  static_cast<const Kokkos::complex<ParamT> *>(m_buffer.ptr);
-              conv_data = std::vector<Kokkos::complex<ParamT>>{
-                  m_ptr, m_ptr + m_buffer.size};
-            }
-            // Return the real component only & ignore params
-            return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
-                conv_data, indices, index_ptr);
-          },
-          "Calculate the expectation value of the given observable.")
-      .def("probs",
-           [](StateVectorKokkos<PrecisionT> &sv,
-              const std::vector<size_t> &wires) {
-             auto m = MeasuresKokkos<PrecisionT>(sv);
-             if (wires.empty()) {
-               return py::array_t<ParamT>(py::cast(m.probs()));
-             }
-
-             const bool is_sorted_wires =
-                 std::is_sorted(wires.begin(), wires.end());
-
-             if (wires.size() == sv.getNumQubits()) {
-               if (is_sorted_wires)
-                 return py::array_t<ParamT>(py::cast(m.probs()));
-             }
-             return py::array_t<ParamT>(py::cast(m.probs(wires)));
-           })
-      .def("GenerateSamples",
-           [](StateVectorKokkos<PrecisionT> &sv, size_t num_wires,
-              size_t num_shots) {
-             auto &&result =
-                 MeasuresKokkos<PrecisionT>(sv).generate_samples(num_shots);
-
-             const size_t ndim = 2;
-             const std::vector<size_t> shape{num_shots, num_wires};
-             constexpr auto sz = sizeof(size_t);
-             const std::vector<size_t> strides{sz * num_wires, sz};
-             // return 2-D NumPy array
-             return py::array(py::buffer_info(
-                 result.data(), /* data as contiguous array  */
-                 sz,            /* size of one scalar        */
-                 py::format_descriptor<size_t>::format(), /* data type */
-                 ndim,   /* number of dimensions      */
-                 shape,  /* shape of the matrix       */
-                 strides /* strides for each axis     */
-                 ));
-           })
-      .def(
-          "DeviceToHost",
-          [](StateVectorKokkos<PrecisionT> &device_sv, np_arr_c &host_sv) {
-            py::buffer_info numpyArrayInfo = host_sv.request();
+    py::class_<StateVectorKokkos<PrecisionT>>(m, class_name.c_str())
+        .def(py::init([](std::size_t num_qubits) {
+            return new StateVectorKokkos<PrecisionT>(num_qubits);
+        }))
+        .def(py::init([](std::size_t num_qubits,
+                         const Kokkos::InitializationSettings &kokkos_args) {
+            return new StateVectorKokkos<PrecisionT>(num_qubits, kokkos_args);
+        }))
+        .def(py::init([](const np_arr_c &arr) {
+            py::buffer_info numpyArrayInfo = arr.request();
             auto *data_ptr =
                 static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-            if (host_sv.size()) {
-              device_sv.DeviceToHost(data_ptr, host_sv.size());
-            }
-          },
-          "Synchronize data from the GPU device to host.")
-      .def("HostToDevice",
-           py::overload_cast<Kokkos::complex<PrecisionT> *, size_t>(
-               &StateVectorKokkos<PrecisionT>::HostToDevice),
-           "Synchronize data from the host device to GPU.")
-      .def(
-          "HostToDevice",
-          [](StateVectorKokkos<PrecisionT> &device_sv,
-             const np_arr_c &host_sv) {
-            const py::buffer_info numpyArrayInfo = host_sv.request();
+            return new StateVectorKokkos<PrecisionT>(
+                data_ptr, static_cast<std::size_t>(arr.size()));
+        }))
+        .def(py::init([](const np_arr_c &arr,
+                         const Kokkos::InitializationSettings &kokkos_args) {
+            py::buffer_info numpyArrayInfo = arr.request();
             auto *data_ptr =
                 static_cast<Kokkos::complex<PrecisionT> *>(numpyArrayInfo.ptr);
-            const auto length = static_cast<size_t>(numpyArrayInfo.shape[0]);
-            if (length) {
-              device_sv.HostToDevice(data_ptr, length);
-            }
-          },
-          "Synchronize data from the host device to GPU.")
-      .def("numQubits", &StateVectorKokkos<PrecisionT>::getNumQubits)
-      .def("dataLength", &StateVectorKokkos<PrecisionT>::getLength)
-      .def("resetKokkos", &StateVectorKokkos<PrecisionT>::resetStateVector);
+            return new StateVectorKokkos<PrecisionT>(
+                data_ptr, static_cast<std::size_t>(arr.size()), kokkos_args);
+        }))
+        .def(
+            "setBasisState",
+            [](StateVectorKokkos<PrecisionT> &sv, const size_t index) {
+                sv.setBasisState(index);
+            },
+            "Create Basis State on Device.")
+        .def(
+            "setStateVector",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &indices, const np_arr_c &state) {
+                const auto buffer = state.request();
+                std::vector<Kokkos::complex<ParamT>> state_kok;
+                if (buffer.size) {
+                    const auto ptr =
+                        static_cast<const Kokkos::complex<ParamT> *>(
+                            buffer.ptr);
+                    state_kok = std::vector<Kokkos::complex<ParamT>>{
+                        ptr, ptr + buffer.size};
+                }
+                sv.setStateVector(indices, state_kok);
+            },
+            "Set State Vector on device with values and their corresponding "
+            "indices for the state vector on device")
+        .def(
+            "Identity",
+            []([[maybe_unused]] StateVectorKokkos<PrecisionT> &sv,
+               [[maybe_unused]] const std::vector<std::size_t> &wires,
+               [[maybe_unused]] bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {},
+            "Apply the Identity gate.")
+        .def(
+            "PauliX",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyPauliX(wires, adjoint);
+            },
+            "Apply the PauliX gate.")
 
-  //***********************************************************************//
-  //                              Observable
-  //***********************************************************************//
+        .def(
+            "PauliY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyPauliY(wires, adjoint);
+            },
+            "Apply the PauliY gate.")
 
-  class_name = "ObservableKokkos_C" + bitsize;
-  py::class_<ObservableKokkos<PrecisionT>,
-             std::shared_ptr<ObservableKokkos<PrecisionT>>>(
-      m, class_name.c_str(), py::module_local());
+        .def(
+            "PauliZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyPauliZ(wires, adjoint);
+            },
+            "Apply the PauliZ gate.")
 
-  class_name = "NamedObsKokkos_C" + bitsize;
-  py::class_<NamedObsKokkos<PrecisionT>,
-             std::shared_ptr<NamedObsKokkos<PrecisionT>>,
-             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                           py::module_local())
-      .def(py::init(
-          [](const std::string &name, const std::vector<size_t> &wires) {
-            return NamedObsKokkos<PrecisionT>(name, wires);
-          }))
-      .def("__repr__", &NamedObsKokkos<PrecisionT>::getObsName)
-      .def("get_wires", &NamedObsKokkos<PrecisionT>::getWires,
-           "Get wires of observables")
-      .def(
-          "__eq__",
-          [](const NamedObsKokkos<PrecisionT> &self, py::handle other) -> bool {
-            if (!py::isinstance<NamedObsKokkos<PrecisionT>>(other)) {
-              return false;
-            }
-            auto other_cast = other.cast<NamedObsKokkos<PrecisionT>>();
-            return self == other_cast;
-          },
-          "Compare two observables");
+        .def(
+            "Hadamard",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyHadamard(wires, adjoint);
+            },
+            "Apply the Hadamard gate.")
 
-  class_name = "HermitianObsKokkos_C" + bitsize;
-  py::class_<HermitianObsKokkos<PrecisionT>,
-             std::shared_ptr<HermitianObsKokkos<PrecisionT>>,
-             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                           py::module_local())
-      .def(py::init(
-          [](const np_arr_c &matrix, const std::vector<size_t> &wires) {
+        .def(
+            "S",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyS(wires, adjoint);
+            },
+            "Apply the S gate.")
+
+        .def(
+            "T",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyT(wires, adjoint);
+            },
+            "Apply the T gate.")
+
+        .def(
+            "CNOT",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyCNOT(wires, adjoint);
+            },
+            "Apply the CNOT gate.")
+
+        .def(
+            "SWAP",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applySWAP(wires, adjoint);
+            },
+            "Apply the SWAP gate.")
+
+        .def(
+            "CSWAP",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyCSWAP(wires, adjoint);
+            },
+            "Apply the CSWAP gate.")
+
+        .def(
+            "Toffoli",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyToffoli(wires, adjoint);
+            },
+            "Apply the Toffoli gate.")
+
+        .def(
+            "CY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyCY(wires, adjoint);
+            },
+            "Apply the CY gate.")
+
+        .def(
+            "CZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               [[maybe_unused]] const std::vector<ParamT> &params) {
+                sv.applyCZ(wires, adjoint);
+            },
+            "Apply the CZ gate.")
+
+        .def(
+            "PhaseShift",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyPhaseShift(wires, adjoint, params);
+            },
+            "Apply the PhaseShift gate.")
+
+        .def("apply",
+             py::overload_cast<
+                 const vector<string> &, const vector<vector<std::size_t>> &,
+                 const vector<bool> &, const vector<vector<PrecisionT>> &>(
+                 &StateVectorKokkos<PrecisionT>::applyOperation))
+
+        .def("apply", py::overload_cast<const vector<string> &,
+                                        const vector<vector<std::size_t>> &,
+                                        const vector<bool> &>(
+                          &StateVectorKokkos<PrecisionT>::applyOperation))
+        .def(
+            "apply",
+            [](StateVectorKokkos<PrecisionT> &sv, const std::string &str,
+               const vector<size_t> &wires, bool inv,
+               [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
+               [[maybe_unused]] const np_arr_c &gate_matrix) {
+                const auto m_buffer = gate_matrix.request();
+                std::vector<Kokkos::complex<ParamT>> conv_matrix;
+                if (m_buffer.size) {
+                    const auto m_ptr =
+                        static_cast<const Kokkos::complex<ParamT> *>(
+                            m_buffer.ptr);
+                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                        m_ptr, m_ptr + m_buffer.size};
+                }
+                sv.applyOperation_std(str, wires, inv, std::vector<ParamT>{},
+                                      conv_matrix);
+            },
+            "Apply operation via the gate matrix")
+        .def("applyGenerator",
+             py::overload_cast<const std::string &, const std::vector<size_t> &,
+                               bool, const vector<PrecisionT> &>(
+                 &StateVectorKokkos<PrecisionT>::applyGenerator))
+        .def(
+            "ControlledPhaseShift",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyControlledPhaseShift(wires, adjoint, params);
+            },
+            "Apply the ControlledPhaseShift gate.")
+
+        .def(
+            "RX",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyRX(wires, adjoint, params);
+            },
+            "Apply the RX gate.")
+
+        .def(
+            "RY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyRY(wires, adjoint, params);
+            },
+            "Apply the RY gate.")
+
+        .def(
+            "RZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyRZ(wires, adjoint, params);
+            },
+            "Apply the RZ gate.")
+
+        .def(
+            "Rot",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyRot(wires, adjoint, params);
+            },
+            "Apply the Rot gate.")
+
+        .def(
+            "CRX",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyCRX(wires, adjoint, params);
+            },
+            "Apply the CRX gate.")
+
+        .def(
+            "CRY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyCRY(wires, adjoint, params);
+            },
+            "Apply the CRY gate.")
+
+        .def(
+            "CRZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyCRZ(wires, adjoint, params);
+            },
+            "Apply the CRZ gate.")
+
+        .def(
+            "CRot",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyCRot(wires, adjoint, params);
+            },
+            "Apply the CRot gate.")
+        .def(
+            "IsingXX",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyIsingXX(wires, adjoint, params);
+            },
+            "Apply the IsingXX gate.")
+        .def(
+            "IsingXY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                sv.applyIsingXY(wires, adjoint, params);
+            },
+            "Apply the IsingXY gate.")
+        .def(
+            "IsingYY",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyIsingYY(wires, adjoint, params);
+            },
+            "Apply the IsingYY gate.")
+        .def(
+            "IsingZZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyIsingZZ(wires, adjoint, params);
+            },
+            "Apply the IsingZZ gate.")
+        .def(
+            "MultiRZ",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyMultiRZ(wires, adjoint, params);
+            },
+            "Apply the MultiRZ gate.")
+        .def(
+            "SingleExcitation",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applySingleExcitation(wires, adjoint, params);
+            },
+            "Apply the SingleExcitation gate.")
+        .def(
+            "SingleExcitationMinus",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applySingleExcitationMinus(wires, adjoint, params);
+            },
+            "Apply the SingleExcitationMinus gate.")
+        .def(
+            "SingleExcitationPlus",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applySingleExcitationPlus(wires, adjoint, params);
+            },
+            "Apply the SingleExcitationPlus gate.")
+        .def(
+            "DoubleExcitation",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyDoubleExcitation(wires, adjoint, params);
+            },
+            "Apply the DoubleExcitation gate.")
+        .def(
+            "DoubleExcitationMinus",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyDoubleExcitationMinus(wires, adjoint, params);
+            },
+            "Apply the DoubleExcitationMinus gate.")
+        .def(
+            "DoubleExcitationPlus",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires, bool adjoint,
+               const std::vector<ParamT> &params) {
+                return sv.applyDoubleExcitationPlus(wires, adjoint, params);
+            },
+            "Apply the DoubleExcitationPlus gate.")
+        .def(
+            "ExpectationValue",
+            [](StateVectorKokkos<PrecisionT> &sv, const std::string &obsName,
+               const std::vector<std::size_t> &wires,
+               [[maybe_unused]] const std::vector<ParamT> &params,
+               [[maybe_unused]] const np_arr_c &gate_matrix) {
+                const auto m_buffer = gate_matrix.request();
+                std::vector<Kokkos::complex<ParamT>> conv_matrix;
+                if (m_buffer.size) {
+                    auto m_ptr =
+                        static_cast<Kokkos::complex<ParamT> *>(m_buffer.ptr);
+                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                        m_ptr, m_ptr + m_buffer.size};
+                }
+                // Return the real component only
+                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                    obsName, wires, params, conv_matrix);
+            },
+            "Calculate the expectation value of the given observable.")
+        .def(
+            "ExpectationValue",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::string> &obsName,
+               const std::vector<std::size_t> &wires,
+               [[maybe_unused]] const std::vector<std::vector<ParamT>> &params,
+               [[maybe_unused]] const np_arr_c &gate_matrix) {
+                std::string obs_concat{"#"};
+                for (const auto &sub : obsName) {
+                    obs_concat += sub;
+                }
+                const auto m_buffer = gate_matrix.request();
+                std::vector<Kokkos::complex<ParamT>> conv_matrix;
+                if (m_buffer.size) {
+                    const auto m_ptr =
+                        static_cast<const Kokkos::complex<ParamT> *>(
+                            m_buffer.ptr);
+                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                        m_ptr, m_ptr + m_buffer.size};
+                }
+                // Return the real component only & ignore params
+                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                    obs_concat, wires, std::vector<ParamT>{}, conv_matrix);
+            },
+            "Calculate the expectation value of the given observable.")
+        .def(
+            "ExpectationValue",
+            [](StateVectorKokkos<PrecisionT> &sv,
+               const std::vector<std::size_t> &wires,
+               const np_arr_c &gate_matrix) {
+                const auto m_buffer = gate_matrix.request();
+                std::vector<Kokkos::complex<ParamT>> conv_matrix;
+                if (m_buffer.size) {
+                    const auto m_ptr =
+                        static_cast<const Kokkos::complex<ParamT> *>(
+                            m_buffer.ptr);
+                    conv_matrix = std::vector<Kokkos::complex<ParamT>>{
+                        m_ptr, m_ptr + m_buffer.size};
+                }
+                // Return the real component only & ignore params
+                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                    wires, conv_matrix);
+            },
+            "Calculate the expectation value of the given observable.")
+
+        .def(
+            "ExpectationValue",
+            [](StateVectorKokkos<PrecisionT> &sv, const np_arr_c &gate_data,
+               const std::vector<std::size_t> &indices,
+               const std::vector<std::size_t> &index_ptr) {
+                const auto m_buffer = gate_data.request();
+                std::vector<Kokkos::complex<ParamT>> conv_data;
+                if (m_buffer.size) {
+                    const auto m_ptr =
+                        static_cast<const Kokkos::complex<ParamT> *>(
+                            m_buffer.ptr);
+                    conv_data = std::vector<Kokkos::complex<ParamT>>{
+                        m_ptr, m_ptr + m_buffer.size};
+                }
+                // Return the real component only & ignore params
+                return MeasuresKokkos<PrecisionT>(sv).getExpectationValue(
+                    conv_data, indices, index_ptr);
+            },
+            "Calculate the expectation value of the given observable.")
+        .def("probs",
+             [](StateVectorKokkos<PrecisionT> &sv,
+                const std::vector<size_t> &wires) {
+                 auto m = MeasuresKokkos<PrecisionT>(sv);
+                 if (wires.empty()) {
+                     return py::array_t<ParamT>(py::cast(m.probs()));
+                 }
+
+                 const bool is_sorted_wires =
+                     std::is_sorted(wires.begin(), wires.end());
+
+                 if (wires.size() == sv.getNumQubits()) {
+                     if (is_sorted_wires)
+                         return py::array_t<ParamT>(py::cast(m.probs()));
+                 }
+                 return py::array_t<ParamT>(py::cast(m.probs(wires)));
+             })
+        .def("GenerateSamples",
+             [](StateVectorKokkos<PrecisionT> &sv, size_t num_wires,
+                size_t num_shots) {
+                 auto &&result =
+                     MeasuresKokkos<PrecisionT>(sv).generate_samples(num_shots);
+
+                 const size_t ndim = 2;
+                 const std::vector<size_t> shape{num_shots, num_wires};
+                 constexpr auto sz = sizeof(size_t);
+                 const std::vector<size_t> strides{sz * num_wires, sz};
+                 // return 2-D NumPy array
+                 return py::array(py::buffer_info(
+                     result.data(), /* data as contiguous array  */
+                     sz,            /* size of one scalar        */
+                     py::format_descriptor<size_t>::format(), /* data type */
+                     ndim,   /* number of dimensions      */
+                     shape,  /* shape of the matrix       */
+                     strides /* strides for each axis     */
+                     ));
+             })
+        .def(
+            "DeviceToHost",
+            [](StateVectorKokkos<PrecisionT> &device_sv, np_arr_c &host_sv) {
+                py::buffer_info numpyArrayInfo = host_sv.request();
+                auto *data_ptr = static_cast<Kokkos::complex<PrecisionT> *>(
+                    numpyArrayInfo.ptr);
+                if (host_sv.size()) {
+                    device_sv.DeviceToHost(data_ptr, host_sv.size());
+                }
+            },
+            "Synchronize data from the GPU device to host.")
+        .def("HostToDevice",
+             py::overload_cast<Kokkos::complex<PrecisionT> *, size_t>(
+                 &StateVectorKokkos<PrecisionT>::HostToDevice),
+             "Synchronize data from the host device to GPU.")
+        .def(
+            "HostToDevice",
+            [](StateVectorKokkos<PrecisionT> &device_sv,
+               const np_arr_c &host_sv) {
+                const py::buffer_info numpyArrayInfo = host_sv.request();
+                auto *data_ptr = static_cast<Kokkos::complex<PrecisionT> *>(
+                    numpyArrayInfo.ptr);
+                const auto length =
+                    static_cast<size_t>(numpyArrayInfo.shape[0]);
+                if (length) {
+                    device_sv.HostToDevice(data_ptr, length);
+                }
+            },
+            "Synchronize data from the host device to GPU.")
+        .def("numQubits", &StateVectorKokkos<PrecisionT>::getNumQubits)
+        .def("dataLength", &StateVectorKokkos<PrecisionT>::getLength)
+        .def("resetKokkos", &StateVectorKokkos<PrecisionT>::resetStateVector);
+
+    //***********************************************************************//
+    //                              Observable
+    //***********************************************************************//
+
+    class_name = "ObservableKokkos_C" + bitsize;
+    py::class_<ObservableKokkos<PrecisionT>,
+               std::shared_ptr<ObservableKokkos<PrecisionT>>>(
+        m, class_name.c_str(), py::module_local());
+
+    class_name = "NamedObsKokkos_C" + bitsize;
+    py::class_<NamedObsKokkos<PrecisionT>,
+               std::shared_ptr<NamedObsKokkos<PrecisionT>>,
+               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                             py::module_local())
+        .def(py::init(
+            [](const std::string &name, const std::vector<size_t> &wires) {
+                return NamedObsKokkos<PrecisionT>(name, wires);
+            }))
+        .def("__repr__", &NamedObsKokkos<PrecisionT>::getObsName)
+        .def("get_wires", &NamedObsKokkos<PrecisionT>::getWires,
+             "Get wires of observables")
+        .def(
+            "__eq__",
+            [](const NamedObsKokkos<PrecisionT> &self,
+               py::handle other) -> bool {
+                if (!py::isinstance<NamedObsKokkos<PrecisionT>>(other)) {
+                    return false;
+                }
+                auto other_cast = other.cast<NamedObsKokkos<PrecisionT>>();
+                return self == other_cast;
+            },
+            "Compare two observables");
+
+    class_name = "HermitianObsKokkos_C" + bitsize;
+    py::class_<HermitianObsKokkos<PrecisionT>,
+               std::shared_ptr<HermitianObsKokkos<PrecisionT>>,
+               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                             py::module_local())
+        .def(py::init([](const np_arr_c &matrix,
+                         const std::vector<size_t> &wires) {
             const auto m_buffer = matrix.request();
             std::vector<std::complex<ParamT>> conv_matrix;
             if (m_buffer.size) {
-              const auto m_ptr =
-                  static_cast<const std::complex<PrecisionT> *>(m_buffer.ptr);
-              conv_matrix = std::vector<std::complex<PrecisionT>>{
-                  m_ptr, m_ptr + m_buffer.size};
+                const auto m_ptr =
+                    static_cast<const std::complex<PrecisionT> *>(m_buffer.ptr);
+                conv_matrix = std::vector<std::complex<PrecisionT>>{
+                    m_ptr, m_ptr + m_buffer.size};
             }
             return HermitianObsKokkos<PrecisionT>(conv_matrix, wires);
-          }))
-      .def("__repr__", &HermitianObsKokkos<PrecisionT>::getObsName)
-      .def("get_wires", &HermitianObsKokkos<PrecisionT>::getWires,
-           "Get wires of observables")
-      .def(
-          "__eq__",
-          [](const HermitianObsKokkos<PrecisionT> &self,
-             py::handle other) -> bool {
-            if (!py::isinstance<HermitianObsKokkos<PrecisionT>>(other)) {
-              return false;
+        }))
+        .def("__repr__", &HermitianObsKokkos<PrecisionT>::getObsName)
+        .def("get_wires", &HermitianObsKokkos<PrecisionT>::getWires,
+             "Get wires of observables")
+        .def(
+            "__eq__",
+            [](const HermitianObsKokkos<PrecisionT> &self,
+               py::handle other) -> bool {
+                if (!py::isinstance<HermitianObsKokkos<PrecisionT>>(other)) {
+                    return false;
+                }
+                auto other_cast = other.cast<HermitianObsKokkos<PrecisionT>>();
+                return self == other_cast;
+            },
+            "Compare two observables");
+
+    class_name = "TensorProdObsKokkos_C" + bitsize;
+    py::class_<TensorProdObsKokkos<PrecisionT>,
+               std::shared_ptr<TensorProdObsKokkos<PrecisionT>>,
+               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                             py::module_local())
+        .def(py::init(
+            [](const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
+                   &obs) { return TensorProdObsKokkos<PrecisionT>(obs); }))
+        .def("__repr__", &TensorProdObsKokkos<PrecisionT>::getObsName)
+        .def("get_wires", &TensorProdObsKokkos<PrecisionT>::getWires,
+             "Get wires of observables")
+        .def(
+            "__eq__",
+            [](const TensorProdObsKokkos<PrecisionT> &self,
+               py::handle other) -> bool {
+                if (!py::isinstance<TensorProdObsKokkos<PrecisionT>>(other)) {
+                    return false;
+                }
+                auto other_cast = other.cast<TensorProdObsKokkos<PrecisionT>>();
+                return self == other_cast;
+            },
+            "Compare two observables");
+
+    class_name = "HamiltonianKokkos_C" + bitsize;
+    using ObsPtr = std::shared_ptr<ObservableKokkos<PrecisionT>>;
+    py::class_<HamiltonianKokkos<PrecisionT>,
+               std::shared_ptr<HamiltonianKokkos<PrecisionT>>,
+               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                             py::module_local())
+        .def(py::init(
+            [](const np_arr_r &coeffs, const std::vector<ObsPtr> &obs) {
+                auto buffer = coeffs.request();
+                const auto ptr = static_cast<const ParamT *>(buffer.ptr);
+                return HamiltonianKokkos<PrecisionT>{
+                    std::vector(ptr, ptr + buffer.size), obs};
+            }))
+        .def("__repr__", &HamiltonianKokkos<PrecisionT>::getObsName)
+        .def("get_wires", &HamiltonianKokkos<PrecisionT>::getWires,
+             "Get wires of observables")
+        .def(
+            "__eq__",
+            [](const HamiltonianKokkos<PrecisionT> &self,
+               py::handle other) -> bool {
+                if (!py::isinstance<HamiltonianKokkos<PrecisionT>>(other)) {
+                    return false;
+                }
+                auto other_cast = other.cast<HamiltonianKokkos<PrecisionT>>();
+                return self == other_cast;
+            },
+            "Compare two observables");
+
+    class_name = "SparseHamiltonianKokkos_C" + bitsize;
+    py::class_<SparseHamiltonianKokkos<PrecisionT>,
+               std::shared_ptr<SparseHamiltonianKokkos<PrecisionT>>,
+               ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
+                                             py::module_local())
+        .def(py::init([](const np_arr_c &data,
+                         const std::vector<std::size_t> &indices,
+                         const std::vector<std::size_t> &indptr,
+                         const std::vector<std::size_t> &wires) {
+            const py::buffer_info buffer_data = data.request();
+            const auto *data_ptr =
+                static_cast<std::complex<PrecisionT> *>(buffer_data.ptr);
+
+            return SparseHamiltonianKokkos<PrecisionT>{
+                std::vector<std::complex<PrecisionT>>(
+                    {data_ptr, data_ptr + data.size()}),
+                indices, indptr, wires};
+        }))
+        .def("__repr__", &SparseHamiltonianKokkos<PrecisionT>::getObsName)
+        .def("get_wires", &SparseHamiltonianKokkos<PrecisionT>::getWires,
+             "Get wires of observables")
+        .def(
+            "__eq__",
+            [](const SparseHamiltonianKokkos<PrecisionT> &self,
+               py::handle other) -> bool {
+                if (!py::isinstance<SparseHamiltonianKokkos<PrecisionT>>(
+                        other)) {
+                    return false;
+                }
+                auto other_cast =
+                    other.cast<SparseHamiltonianKokkos<PrecisionT>>();
+                return self == other_cast;
+            },
+            "Compare two observables");
+
+    //***********************************************************************//
+    //                              Operations
+    //***********************************************************************//
+    class_name = "OpsStructKokkos_C" + bitsize;
+    py::class_<OpsData<PrecisionT>>(m, class_name.c_str(), py::module_local())
+        .def(py::init<
+             const std::vector<std::string> &,
+             const std::vector<std::vector<ParamT>> &,
+             const std::vector<std::vector<size_t>> &,
+             const std::vector<bool> &,
+             const std::vector<std::vector<std::complex<PrecisionT>>> &>())
+        .def("__repr__", [](const OpsData<PrecisionT> &ops) {
+            using namespace Pennylane::Util;
+            std::ostringstream ops_stream;
+            for (size_t op = 0; op < ops.getSize(); op++) {
+                ops_stream << "{'name': " << ops.getOpsName()[op];
+                ops_stream << ", 'params': " << ops.getOpsParams()[op];
+                ops_stream << ", 'inv': " << ops.getOpsInverses()[op];
+                ops_stream << "}";
+                if (op < ops.getSize() - 1) {
+                    ops_stream << ",";
+                }
             }
-            auto other_cast = other.cast<HermitianObsKokkos<PrecisionT>>();
-            return self == other_cast;
-          },
-          "Compare two observables");
+            return "Operations: [" + ops_stream.str() + "]";
+        });
 
-  class_name = "TensorProdObsKokkos_C" + bitsize;
-  py::class_<TensorProdObsKokkos<PrecisionT>,
-             std::shared_ptr<TensorProdObsKokkos<PrecisionT>>,
-             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                           py::module_local())
-      .def(py::init(
-          [](const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
-                 &obs) { return TensorProdObsKokkos<PrecisionT>(obs); }))
-      .def("__repr__", &TensorProdObsKokkos<PrecisionT>::getObsName)
-      .def("get_wires", &TensorProdObsKokkos<PrecisionT>::getWires,
-           "Get wires of observables")
-      .def(
-          "__eq__",
-          [](const TensorProdObsKokkos<PrecisionT> &self,
-             py::handle other) -> bool {
-            if (!py::isinstance<TensorProdObsKokkos<PrecisionT>>(other)) {
-              return false;
-            }
-            auto other_cast = other.cast<TensorProdObsKokkos<PrecisionT>>();
-            return self == other_cast;
-          },
-          "Compare two observables");
+    //***********************************************************************//
+    //                              Adj Jac
+    //***********************************************************************//
 
-  class_name = "HamiltonianKokkos_C" + bitsize;
-  using ObsPtr = std::shared_ptr<ObservableKokkos<PrecisionT>>;
-  py::class_<HamiltonianKokkos<PrecisionT>,
-             std::shared_ptr<HamiltonianKokkos<PrecisionT>>,
-             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                           py::module_local())
-      .def(py::init([](const np_arr_r &coeffs, const std::vector<ObsPtr> &obs) {
-        auto buffer = coeffs.request();
-        const auto ptr = static_cast<const ParamT *>(buffer.ptr);
-        return HamiltonianKokkos<PrecisionT>{
-            std::vector(ptr, ptr + buffer.size), obs};
-      }))
-      .def("__repr__", &HamiltonianKokkos<PrecisionT>::getObsName)
-      .def("get_wires", &HamiltonianKokkos<PrecisionT>::getWires,
-           "Get wires of observables")
-      .def(
-          "__eq__",
-          [](const HamiltonianKokkos<PrecisionT> &self,
-             py::handle other) -> bool {
-            if (!py::isinstance<HamiltonianKokkos<PrecisionT>>(other)) {
-              return false;
-            }
-            auto other_cast = other.cast<HamiltonianKokkos<PrecisionT>>();
-            return self == other_cast;
-          },
-          "Compare two observables");
+    class_name = "AdjointJacobianKokkos_C" + bitsize;
+    py::class_<AdjointJacobianKokkos<PrecisionT>>(m, class_name.c_str(),
+                                                  py::module_local())
+        .def(py::init<>())
+        .def("create_ops_list",
+             [](AdjointJacobianKokkos<PrecisionT> &adj,
+                const std::vector<std::string> &ops_name,
+                const std::vector<np_arr_r> &ops_params,
+                const std::vector<std::vector<size_t>> &ops_wires,
+                const std::vector<bool> &ops_inverses,
+                const std::vector<np_arr_c> &ops_matrices) {
+                 std::vector<std::vector<PrecisionT>> conv_params(
+                     ops_params.size());
+                 std::vector<std::vector<std::complex<PrecisionT>>>
+                     conv_matrices(ops_matrices.size());
+                 static_cast<void>(adj);
+                 for (size_t op = 0; op < ops_name.size(); op++) {
+                     const auto p_buffer = ops_params[op].request();
+                     const auto m_buffer = ops_matrices[op].request();
+                     if (p_buffer.size) {
+                         const auto *const p_ptr =
+                             static_cast<const ParamT *>(p_buffer.ptr);
+                         conv_params[op] =
+                             std::vector<ParamT>{p_ptr, p_ptr + p_buffer.size};
+                     }
 
-  class_name = "SparseHamiltonianKokkos_C" + bitsize;
-  py::class_<SparseHamiltonianKokkos<PrecisionT>,
-             std::shared_ptr<SparseHamiltonianKokkos<PrecisionT>>,
-             ObservableKokkos<PrecisionT>>(m, class_name.c_str(),
-                                           py::module_local())
-      .def(py::init([](const np_arr_c &data,
-                       const std::vector<std::size_t> &indices,
-                       const std::vector<std::size_t> &indptr,
-                       const std::vector<std::size_t> &wires) {
-        const py::buffer_info buffer_data = data.request();
-        const auto *data_ptr =
-            static_cast<std::complex<PrecisionT> *>(buffer_data.ptr);
+                     if (m_buffer.size) {
+                         const auto m_ptr =
+                             static_cast<const std::complex<ParamT> *>(
+                                 m_buffer.ptr);
+                         conv_matrices[op] = std::vector<std::complex<ParamT>>{
+                             m_ptr, m_ptr + m_buffer.size};
+                     }
+                 }
 
-        return SparseHamiltonianKokkos<PrecisionT>{
-            std::vector<std::complex<PrecisionT>>(
-                {data_ptr, data_ptr + data.size()}),
-            indices, indptr, wires};
-      }))
-      .def("__repr__", &SparseHamiltonianKokkos<PrecisionT>::getObsName)
-      .def("get_wires", &SparseHamiltonianKokkos<PrecisionT>::getWires,
-           "Get wires of observables")
-      .def(
-          "__eq__",
-          [](const SparseHamiltonianKokkos<PrecisionT> &self,
-             py::handle other) -> bool {
-            if (!py::isinstance<SparseHamiltonianKokkos<PrecisionT>>(other)) {
-              return false;
-            }
-            auto other_cast = other.cast<SparseHamiltonianKokkos<PrecisionT>>();
-            return self == other_cast;
-          },
-          "Compare two observables");
-
-  //***********************************************************************//
-  //                              Operations
-  //***********************************************************************//
-  class_name = "OpsStructKokkos_C" + bitsize;
-  py::class_<OpsData<PrecisionT>>(m, class_name.c_str(), py::module_local())
-      .def(py::init<
-           const std::vector<std::string> &,
-           const std::vector<std::vector<ParamT>> &,
-           const std::vector<std::vector<size_t>> &, const std::vector<bool> &,
-           const std::vector<std::vector<std::complex<PrecisionT>>> &>())
-      .def("__repr__", [](const OpsData<PrecisionT> &ops) {
-        using namespace Pennylane::Util;
-        std::ostringstream ops_stream;
-        for (size_t op = 0; op < ops.getSize(); op++) {
-          ops_stream << "{'name': " << ops.getOpsName()[op];
-          ops_stream << ", 'params': " << ops.getOpsParams()[op];
-          ops_stream << ", 'inv': " << ops.getOpsInverses()[op];
-          ops_stream << "}";
-          if (op < ops.getSize() - 1) {
-            ops_stream << ",";
-          }
-        }
-        return "Operations: [" + ops_stream.str() + "]";
-      });
-
-  //***********************************************************************//
-  //                              Adj Jac
-  //***********************************************************************//
-
-  class_name = "AdjointJacobianKokkos_C" + bitsize;
-  py::class_<AdjointJacobianKokkos<PrecisionT>>(m, class_name.c_str(),
-                                                py::module_local())
-      .def(py::init<>())
-      .def("create_ops_list",
-           [](AdjointJacobianKokkos<PrecisionT> &adj,
-              const std::vector<std::string> &ops_name,
-              const std::vector<np_arr_r> &ops_params,
-              const std::vector<std::vector<size_t>> &ops_wires,
-              const std::vector<bool> &ops_inverses,
-              const std::vector<np_arr_c> &ops_matrices) {
-             std::vector<std::vector<PrecisionT>> conv_params(
-                 ops_params.size());
-             std::vector<std::vector<std::complex<PrecisionT>>> conv_matrices(
-                 ops_matrices.size());
-             static_cast<void>(adj);
-             for (size_t op = 0; op < ops_name.size(); op++) {
-               const auto p_buffer = ops_params[op].request();
-               const auto m_buffer = ops_matrices[op].request();
-               if (p_buffer.size) {
-                 const auto *const p_ptr =
-                     static_cast<const ParamT *>(p_buffer.ptr);
-                 conv_params[op] =
-                     std::vector<ParamT>{p_ptr, p_ptr + p_buffer.size};
-               }
-
-               if (m_buffer.size) {
-                 const auto m_ptr =
-                     static_cast<const std::complex<ParamT> *>(m_buffer.ptr);
-                 conv_matrices[op] = std::vector<std::complex<ParamT>>{
-                     m_ptr, m_ptr + m_buffer.size};
-               }
-             }
-
-             return OpsData<PrecisionT>{ops_name, conv_params, ops_wires,
-                                        ops_inverses, conv_matrices};
-           })
-      .def("adjoint_jacobian",
-           &AdjointJacobianKokkos<PrecisionT>::adjointJacobian)
-      .def("adjoint_jacobian",
-           [](AdjointJacobianKokkos<PrecisionT> &adj,
-              const StateVectorKokkos<PrecisionT> &sv,
-              const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
-                  &observables,
-              const OpsData<PrecisionT> &operations,
-              const std::vector<size_t> &trainableParams) {
-             std::vector<std::vector<PrecisionT>> jac(
-                 observables.size(),
-                 std::vector<PrecisionT>(trainableParams.size(), 0));
-             adj.adjointJacobian(sv, jac, observables, operations,
-                                 trainableParams, false);
-             return py::array_t<ParamT>(py::cast(jac));
-           });
+                 return OpsData<PrecisionT>{ops_name, conv_params, ops_wires,
+                                            ops_inverses, conv_matrices};
+             })
+        .def("adjoint_jacobian",
+             &AdjointJacobianKokkos<PrecisionT>::adjointJacobian)
+        .def("adjoint_jacobian",
+             [](AdjointJacobianKokkos<PrecisionT> &adj,
+                const StateVectorKokkos<PrecisionT> &sv,
+                const std::vector<std::shared_ptr<ObservableKokkos<PrecisionT>>>
+                    &observables,
+                const OpsData<PrecisionT> &operations,
+                const std::vector<size_t> &trainableParams) {
+                 std::vector<std::vector<PrecisionT>> jac(
+                     observables.size(),
+                     std::vector<PrecisionT>(trainableParams.size(), 0));
+                 adj.adjointJacobian(sv, jac, observables, operations,
+                                     trainableParams, false);
+                 return py::array_t<ParamT>(py::cast(jac));
+             });
 }
 
 // Necessary to avoid mangled names when manually building module
@@ -817,122 +830,130 @@ extern "C" {
 PYBIND11_MODULE(lightning_kokkos_qubit_ops, // NOLINT: No control over
                                             // Pybind internals
                 m) {
-  // Suppress doxygen autogenerated signatures
+    // Suppress doxygen autogenerated signatures
 
-  py::options options;
-  options.disable_function_signatures();
-  py::register_exception<LightningException>(m, "PLException");
+    py::options options;
+    options.disable_function_signatures();
+    py::register_exception<LightningException>(m, "PLException");
 
-  StateVectorKokkos_class_bindings<float, float>(m);
-  StateVectorKokkos_class_bindings<double, double>(m);
+    StateVectorKokkos_class_bindings<float, float>(m);
+    StateVectorKokkos_class_bindings<double, double>(m);
 
-  m.def("kokkos_start", []() { Kokkos::initialize(); });
-  m.def("kokkos_end", []() { Kokkos::finalize(); });
-  m.def("kokkos_config_info", &getConfig, "Kokkos configurations query.");
-  m.def(
-      "print_configuration",
-      []() {
-        std::ostringstream buffer;
-        Kokkos::print_configuration(buffer, true);
-        return buffer.str();
-      },
-      "Kokkos configurations query.");
+    m.def("kokkos_start", []() { Kokkos::initialize(); });
+    m.def("kokkos_end", []() { Kokkos::finalize(); });
+    m.def("kokkos_config_info", &getConfig, "Kokkos configurations query.");
+    m.def(
+        "print_configuration",
+        []() {
+            std::ostringstream buffer;
+            Kokkos::print_configuration(buffer, true);
+            return buffer.str();
+        },
+        "Kokkos configurations query.");
 
-  py::class_<Kokkos::InitializationSettings>(m, "InitializationSettings")
-      .def(py::init<>())
-      .def("get_num_threads", &Kokkos::InitializationSettings::get_num_threads,
-           "Number of threads to use with the host parallel backend. Must be "
-           "greater than zero.")
-      .def("get_device_id", &Kokkos::InitializationSettings::get_device_id,
-           "Device to use with the device parallel backend. Valid IDs are "
-           "zero to number of GPU(s) available for execution minus one.")
-      .def("get_map_device_id_by",
-           &Kokkos::InitializationSettings::get_map_device_id_by,
-           "Strategy to select a device automatically from the GPUs available "
-           "for execution. Must be either mpi_rank"
-           "for round-robin assignment based on the local MPI rank or random.")
-      .def("get_disable_warnings",
-           &Kokkos::InitializationSettings::get_disable_warnings,
-           "Whether to disable warning messages.")
-      .def("get_print_configuration",
-           &Kokkos::InitializationSettings::get_print_configuration,
-           "Whether to print the configuration after initialization.")
-      .def("get_tune_internals",
-           &Kokkos::InitializationSettings::get_tune_internals,
-           "Whether to allow autotuning internals instead of using "
-           "heuristics.")
-      .def("get_tools_libs", &Kokkos::InitializationSettings::get_tools_libs,
-           "Which tool dynamic library to load. Must either be the full path "
-           "to library or the name of library if the path is present in the "
-           "runtime library search path (e.g. LD_LIBRARY_PATH)")
-      .def("get_tools_help", &Kokkos::InitializationSettings::get_tools_help,
-           "Query the loaded tool for its command-line options support.")
-      .def("get_tools_args", &Kokkos::InitializationSettings::get_tools_args,
-           "Options to pass to the loaded tool as command-line arguments.")
-      .def("has_num_threads", &Kokkos::InitializationSettings::has_num_threads,
-           "Number of threads to use with the host parallel backend. Must be "
-           "greater than zero.")
-      .def("has_device_id", &Kokkos::InitializationSettings::has_device_id,
-           "Device to use with the device parallel backend. Valid IDs are zero "
-           "to number of GPU(s) available for execution minus one.")
-      .def("has_map_device_id_by",
-           &Kokkos::InitializationSettings::has_map_device_id_by,
-           "Strategy to select a device automatically from the GPUs available "
-           "for execution. Must be either mpi_rank"
-           "for round-robin assignment based on the local MPI rank or random.")
-      .def("has_disable_warnings",
-           &Kokkos::InitializationSettings::has_disable_warnings,
-           "Whether to disable warning messages.")
-      .def("has_print_configuration",
-           &Kokkos::InitializationSettings::has_print_configuration,
-           "Whether to print the configuration after initialization.")
-      .def("has_tune_internals",
-           &Kokkos::InitializationSettings::has_tune_internals,
-           "Whether to allow autotuning internals instead of using heuristics.")
-      .def(
-          "has_tools_libs", &Kokkos::InitializationSettings::has_tools_libs,
-          "Which tool dynamic library to load. Must either be the full path to "
-          "library or the name of library if the path is present in the "
-          "runtime library search path (e.g. LD_LIBRARY_PATH)")
-      .def("has_tools_help", &Kokkos::InitializationSettings::has_tools_help,
-           "Query the loaded tool for its command-line options support.")
-      .def("has_tools_args", &Kokkos::InitializationSettings::has_tools_args,
-           "Options to pass to the loaded tool as command-line arguments.")
-      .def("set_num_threads", &Kokkos::InitializationSettings::set_num_threads,
-           "Number of threads to use with the host parallel backend. Must be "
-           "greater than zero.")
-      .def("set_device_id", &Kokkos::InitializationSettings::set_device_id,
-           "Device to use with the device parallel backend. Valid IDs are "
-           "zero to number of GPU(s) available for execution minus one.")
-      .def("set_map_device_id_by",
-           &Kokkos::InitializationSettings::set_map_device_id_by,
-           "Strategy to select a device automatically from the GPUs available "
-           "for execution. Must be either mpi_rank"
-           "for round-robin assignment based on the local MPI rank or random.")
-      .def("set_disable_warnings",
-           &Kokkos::InitializationSettings::set_disable_warnings,
-           "Whether to disable warning messages.")
-      .def("set_print_configuration",
-           &Kokkos::InitializationSettings::set_print_configuration,
-           "Whether to print the configuration after initialization.")
-      .def("set_tune_internals",
-           &Kokkos::InitializationSettings::set_tune_internals,
-           "Whether to allow autotuning internals instead of using "
-           "heuristics.")
-      .def("set_tools_libs", &Kokkos::InitializationSettings::set_tools_libs,
-           "Which tool dynamic library to load. Must either be the full path "
-           "to library or the name of library if the path is present in the "
-           "runtime library search path (e.g. LD_LIBRARY_PATH)")
-      .def("set_tools_help", &Kokkos::InitializationSettings::set_tools_help,
-           "Query the loaded tool for its command-line options support.")
-      .def("set_tools_args", &Kokkos::InitializationSettings::set_tools_args,
-           "Options to pass to the loaded tool as command-line arguments.")
-      .def("__repr__", [](const Kokkos::InitializationSettings &args) {
-        using namespace Pennylane::Util;
-        std::ostringstream args_stream;
-        args_stream << args;
-        return args_stream.str();
-      });
+    py::class_<Kokkos::InitializationSettings>(m, "InitializationSettings")
+        .def(py::init<>())
+        .def("get_num_threads",
+             &Kokkos::InitializationSettings::get_num_threads,
+             "Number of threads to use with the host parallel backend. Must be "
+             "greater than zero.")
+        .def("get_device_id", &Kokkos::InitializationSettings::get_device_id,
+             "Device to use with the device parallel backend. Valid IDs are "
+             "zero to number of GPU(s) available for execution minus one.")
+        .def(
+            "get_map_device_id_by",
+            &Kokkos::InitializationSettings::get_map_device_id_by,
+            "Strategy to select a device automatically from the GPUs available "
+            "for execution. Must be either mpi_rank"
+            "for round-robin assignment based on the local MPI rank or random.")
+        .def("get_disable_warnings",
+             &Kokkos::InitializationSettings::get_disable_warnings,
+             "Whether to disable warning messages.")
+        .def("get_print_configuration",
+             &Kokkos::InitializationSettings::get_print_configuration,
+             "Whether to print the configuration after initialization.")
+        .def("get_tune_internals",
+             &Kokkos::InitializationSettings::get_tune_internals,
+             "Whether to allow autotuning internals instead of using "
+             "heuristics.")
+        .def("get_tools_libs", &Kokkos::InitializationSettings::get_tools_libs,
+             "Which tool dynamic library to load. Must either be the full path "
+             "to library or the name of library if the path is present in the "
+             "runtime library search path (e.g. LD_LIBRARY_PATH)")
+        .def("get_tools_help", &Kokkos::InitializationSettings::get_tools_help,
+             "Query the loaded tool for its command-line options support.")
+        .def("get_tools_args", &Kokkos::InitializationSettings::get_tools_args,
+             "Options to pass to the loaded tool as command-line arguments.")
+        .def("has_num_threads",
+             &Kokkos::InitializationSettings::has_num_threads,
+             "Number of threads to use with the host parallel backend. Must be "
+             "greater than zero.")
+        .def("has_device_id", &Kokkos::InitializationSettings::has_device_id,
+             "Device to use with the device parallel backend. Valid IDs are "
+             "zero "
+             "to number of GPU(s) available for execution minus one.")
+        .def(
+            "has_map_device_id_by",
+            &Kokkos::InitializationSettings::has_map_device_id_by,
+            "Strategy to select a device automatically from the GPUs available "
+            "for execution. Must be either mpi_rank"
+            "for round-robin assignment based on the local MPI rank or random.")
+        .def("has_disable_warnings",
+             &Kokkos::InitializationSettings::has_disable_warnings,
+             "Whether to disable warning messages.")
+        .def("has_print_configuration",
+             &Kokkos::InitializationSettings::has_print_configuration,
+             "Whether to print the configuration after initialization.")
+        .def("has_tune_internals",
+             &Kokkos::InitializationSettings::has_tune_internals,
+             "Whether to allow autotuning internals instead of using "
+             "heuristics.")
+        .def("has_tools_libs", &Kokkos::InitializationSettings::has_tools_libs,
+             "Which tool dynamic library to load. Must either be the full path "
+             "to "
+             "library or the name of library if the path is present in the "
+             "runtime library search path (e.g. LD_LIBRARY_PATH)")
+        .def("has_tools_help", &Kokkos::InitializationSettings::has_tools_help,
+             "Query the loaded tool for its command-line options support.")
+        .def("has_tools_args", &Kokkos::InitializationSettings::has_tools_args,
+             "Options to pass to the loaded tool as command-line arguments.")
+        .def("set_num_threads",
+             &Kokkos::InitializationSettings::set_num_threads,
+             "Number of threads to use with the host parallel backend. Must be "
+             "greater than zero.")
+        .def("set_device_id", &Kokkos::InitializationSettings::set_device_id,
+             "Device to use with the device parallel backend. Valid IDs are "
+             "zero to number of GPU(s) available for execution minus one.")
+        .def(
+            "set_map_device_id_by",
+            &Kokkos::InitializationSettings::set_map_device_id_by,
+            "Strategy to select a device automatically from the GPUs available "
+            "for execution. Must be either mpi_rank"
+            "for round-robin assignment based on the local MPI rank or random.")
+        .def("set_disable_warnings",
+             &Kokkos::InitializationSettings::set_disable_warnings,
+             "Whether to disable warning messages.")
+        .def("set_print_configuration",
+             &Kokkos::InitializationSettings::set_print_configuration,
+             "Whether to print the configuration after initialization.")
+        .def("set_tune_internals",
+             &Kokkos::InitializationSettings::set_tune_internals,
+             "Whether to allow autotuning internals instead of using "
+             "heuristics.")
+        .def("set_tools_libs", &Kokkos::InitializationSettings::set_tools_libs,
+             "Which tool dynamic library to load. Must either be the full path "
+             "to library or the name of library if the path is present in the "
+             "runtime library search path (e.g. LD_LIBRARY_PATH)")
+        .def("set_tools_help", &Kokkos::InitializationSettings::set_tools_help,
+             "Query the loaded tool for its command-line options support.")
+        .def("set_tools_args", &Kokkos::InitializationSettings::set_tools_args,
+             "Options to pass to the loaded tool as command-line arguments.")
+        .def("__repr__", [](const Kokkos::InitializationSettings &args) {
+            using namespace Pennylane::Util;
+            std::ostringstream args_stream;
+            args_stream << args;
+            return args_stream.str();
+        });
 }
 }
 

--- a/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
@@ -852,7 +852,18 @@ PYBIND11_MODULE(lightning_kokkos_qubit_ops, // NOLINT: No control over
         "Kokkos configurations query.");
 
     py::class_<Kokkos::InitializationSettings>(m, "InitializationSettings")
-        .def(py::init<>())
+        .def(py::init([]() {
+            return Kokkos::InitializationSettings()
+                .set_num_threads(0)
+                .set_device_id(0)
+                .set_map_device_id_by("")
+                .set_disable_warnings(0)
+                .set_print_configuration(0)
+                .set_tune_internals(0)
+                .set_tools_libs("")
+                .set_tools_help(0)
+                .set_tools_args("");
+        }))
         .def("get_num_threads",
              &Kokkos::InitializationSettings::get_num_threads,
              "Number of threads to use with the host parallel backend. Must be "

--- a/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
+++ b/pennylane_lightning_kokkos/src/bindings/Bindings.cpp
@@ -829,6 +829,14 @@ PYBIND11_MODULE(lightning_kokkos_qubit_ops, // NOLINT: No control over
   m.def("kokkos_start", []() { Kokkos::initialize(); });
   m.def("kokkos_end", []() { Kokkos::finalize(); });
   m.def("kokkos_config_info", &getConfig, "Kokkos configurations query.");
+  m.def(
+      "print_configuration",
+      []() {
+        std::ostringstream buffer;
+        Kokkos::print_configuration(buffer, true);
+        return buffer.str();
+      },
+      "Kokkos configurations query.");
 
   py::class_<Kokkos::InitializationSettings>(m, "InitializationSettings")
       .def(py::init<>())

--- a/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
+++ b/pennylane_lightning_kokkos/src/simulator/StateVectorKokkos.hpp
@@ -128,7 +128,7 @@ template <class Precision> class StateVectorKokkos {
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
     StateVectorKokkos() = delete;
-    StateVectorKokkos(size_t num_qubits, const Kokkos::InitArguments &kokkos_args = {})
+    StateVectorKokkos(size_t num_qubits, const Kokkos::InitializationSettings &kokkos_args = {})
         : gates_{
                 //Identity
                  {"PauliX", 
@@ -528,7 +528,7 @@ template <class Precision> class StateVectorKokkos {
      * @param num_qubits Number of qubits
      */
     StateVectorKokkos(Kokkos::complex<Precision> *hostdata_, size_t length,
-                      const Kokkos::InitArguments &kokkos_args = {})
+                      const Kokkos::InitializationSettings &kokkos_args = {})
         : StateVectorKokkos(Util::log2(length), kokkos_args) {
         HostToDevice(hostdata_, length);
     }
@@ -539,7 +539,7 @@ template <class Precision> class StateVectorKokkos {
      * @param other Another state vector
      */
     StateVectorKokkos(const StateVectorKokkos &other,
-                      const Kokkos::InitArguments &kokkos_args = {})
+                      const Kokkos::InitializationSettings &kokkos_args = {})
         : StateVectorKokkos(other.getNumQubits(), kokkos_args) {
         this->DeviceToDevice(other.getData());
     }

--- a/pennylane_lightning_kokkos/src/tests/Test_AdjointDiffKokkos.cpp
+++ b/pennylane_lightning_kokkos/src/tests/Test_AdjointDiffKokkos.cpp
@@ -36,7 +36,8 @@ TEST_CASE("AdjointJacobianKokkos::AdjointJacobianKokkos Op=RX, Obs=Z",
     AdjointJacobianKokkos<double> adj;
     std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
 
-    const Kokkos::InitArguments num_threads_2 = {2};
+    const auto num_threads_2 =
+        Kokkos::InitializationSettings().set_num_threads(2);
     const size_t num_qubits = 1;
     const size_t num_params = 3;
     const size_t num_obs = 1;

--- a/pennylane_lightning_kokkos/src/util/Util.hpp
+++ b/pennylane_lightning_kokkos/src/util/Util.hpp
@@ -46,7 +46,7 @@
 namespace Pennylane::Util {
 template <typename T> struct remove_complex { using type = T; };
 template <typename T> struct remove_complex<std::complex<T>> {
-  using type = T;
+    using type = T;
 };
 template <typename T> using remove_complex_t = typename remove_complex<T>::type;
 
@@ -60,26 +60,27 @@ template <typename T> constexpr bool is_complex_v = is_complex<T>::value;
  * Utility hash function for complex vectors representing matrices.
  */
 struct MatrixHasher {
-  template <class Precision = double>
-  std::size_t
-  operator()(const std::vector<std::complex<Precision>> &matrix) const {
-    std::size_t hash_val = matrix.size();
-    for (const auto &c_val : matrix) {
-      hash_val ^= std::hash<Precision>()(c_val.real()) ^
-                  std::hash<Precision>()(c_val.imag());
+    template <class Precision = double>
+    std::size_t
+    operator()(const std::vector<std::complex<Precision>> &matrix) const {
+        std::size_t hash_val = matrix.size();
+        for (const auto &c_val : matrix) {
+            hash_val ^= std::hash<Precision>()(c_val.real()) ^
+                        std::hash<Precision>()(c_val.imag());
+        }
+        return hash_val;
     }
-    return hash_val;
-  }
 };
 
 struct BitSwapFunctor {
-  BitSwapFunctor() = default;
+    BitSwapFunctor() = default;
 
-  KOKKOS_INLINE_FUNCTION
-  std::size_t operator()(const size_t &bits, const size_t &i, const size_t &j) {
-    size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
-    return bits ^ ((x << i) | (x << j));
-  }
+    KOKKOS_INLINE_FUNCTION
+    std::size_t operator()(const size_t &bits, const size_t &i,
+                           const size_t &j) {
+        size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
+        return bits ^ ((x << i) | (x << j));
+    }
 };
 
 /**
@@ -87,22 +88,22 @@ struct BitSwapFunctor {
  */
 inline auto constexpr bitswap(size_t bits, const size_t i, const size_t j)
     -> size_t {
-  size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
-  return bits ^ ((x << i) | (x << j));
+    size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
+    return bits ^ ((x << i) | (x << j));
 }
 
 /**
  * @brief Fill ones from LSB to rev_wire
  */
 inline size_t fillTrailingOnes(size_t pos) {
-  return (pos == 0) ? 0 : (~size_t(0) >> (CHAR_BIT * sizeof(size_t) - pos));
+    return (pos == 0) ? 0 : (~size_t(0) >> (CHAR_BIT * sizeof(size_t) - pos));
 }
 
 /**
  * @brief Fill ones from MSB to pos
  */
 inline auto constexpr fillLeadingOnes(size_t pos) -> size_t {
-  return (~size_t(0)) << pos;
+    return (~size_t(0)) << pos;
 }
 
 /**
@@ -117,7 +118,7 @@ inline auto constexpr fillLeadingOnes(size_t pos) -> size_t {
 template <class T, class U = T>
 inline static constexpr auto ConstMult(U a, std::complex<T> b)
     -> std::complex<T> {
-  return {a * b.real(), a * b.imag()};
+    return {a * b.real(), a * b.imag()};
 }
 
 /**
@@ -132,14 +133,14 @@ inline static constexpr auto ConstMult(U a, std::complex<T> b)
 template <class T, class U = T>
 inline static constexpr auto ConstMult(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-  return {a.real() * b.real() - a.imag() * b.imag(),
-          a.real() * b.imag() + a.imag() * b.real()};
+    return {a.real() * b.real() - a.imag() * b.imag(),
+            a.real() * b.imag() + a.imag() * b.real()};
 }
 template <class T, class U = T>
 inline static constexpr auto ConstMultConj(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-  return {a.real() * b.real() + a.imag() * b.imag(),
-          -a.imag() * b.real() + a.real() * b.imag()};
+    return {a.real() * b.real() + a.imag() * b.imag(),
+            -a.imag() * b.real() + a.real() * b.imag()};
 }
 
 /**
@@ -154,7 +155,7 @@ inline static constexpr auto ConstMultConj(std::complex<U> a, std::complex<T> b)
 template <class T, class U = T>
 inline static constexpr auto ConstSum(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-  return a + b;
+    return a + b;
 }
 
 /**
@@ -165,7 +166,7 @@ inline static constexpr auto ConstSum(std::complex<U> a, std::complex<T> b)
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto ONE() -> ComplexT<T> {
-  return {1, 0};
+    return {1, 0};
 }
 
 /**
@@ -176,7 +177,7 @@ inline static constexpr auto ONE() -> ComplexT<T> {
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto ZERO() -> ComplexT<T> {
-  return {0, 0};
+    return {0, 0};
 }
 
 /**
@@ -187,17 +188,17 @@ inline static constexpr auto ZERO() -> ComplexT<T> {
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto IMAG() -> ComplexT<T> {
-  return {0, 1};
+    return {0, 1};
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto HALF() -> ComplexT<T> {
-  return {0.5, 0};
+    return {0.5, 0};
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto NEGONE() -> ComplexT<T> {
-  return {-1, 0};
+    return {-1, 0};
 }
 
 /**
@@ -209,19 +210,19 @@ inline static constexpr auto NEGONE() -> ComplexT<T> {
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto SQRT2() -> ComplexT<T> {
 #if __cpp_lib_math_constants >= 201907L
-  return std::numbers::sqrt2_v<T>;
+    return std::numbers::sqrt2_v<T>;
 #else
-  if constexpr (std::is_same_v<T, float>) {
-    return {0x1.6a09e6p+0F, 0}; // NOLINT: To be replaced in C++20
-  } else {
-    return {0x1.6a09e667f3bcdp+0, 0}; // NOLINT: To be replaced in C++20
-  }
+    if constexpr (std::is_same_v<T, float>) {
+        return {0x1.6a09e6p+0F, 0}; // NOLINT: To be replaced in C++20
+    } else {
+        return {0x1.6a09e667f3bcdp+0, 0}; // NOLINT: To be replaced in C++20
+    }
 #endif
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline constexpr auto INVSQRT2() -> ComplexT<T> {
-  return {1 / real(SQRT2<ComplexT, T>()), 0};
+    return {1 / real(SQRT2<ComplexT, T>()), 0};
 }
 
 /**
@@ -231,7 +232,7 @@ inline constexpr auto INVSQRT2() -> ComplexT<T> {
  * @return value of 2^n
  */
 inline auto exp2(const size_t &n) -> size_t {
-  return static_cast<size_t>(1) << n;
+    return static_cast<size_t>(1) << n;
 }
 
 /**
@@ -241,7 +242,7 @@ inline auto exp2(const size_t &n) -> size_t {
  * @return size_t
  */
 inline auto log2(size_t value) -> size_t {
-  return static_cast<size_t>(std::log2(value));
+    return static_cast<size_t>(std::log2(value));
 }
 
 /**
@@ -253,8 +254,8 @@ inline auto log2(size_t value) -> size_t {
  * @return decimal value for the qubit at specified index
  */
 inline auto maxDecimalForQubit(size_t qubitIndex, size_t qubits) -> size_t {
-  assert(qubitIndex < qubits);
-  return exp2(qubits - qubitIndex - 1);
+    assert(qubitIndex < qubits);
+    return exp2(qubits - qubitIndex - 1);
 }
 
 /**
@@ -265,20 +266,20 @@ inline auto maxDecimalForQubit(size_t qubitIndex, size_t qubits) -> size_t {
  * @return size_t Number of wires.
  */
 template <class T> inline auto dimSize(const std::vector<T> &data) -> size_t {
-  const size_t s = data.size();
-  const auto s_sqrt = static_cast<size_t>(std::floor(std::sqrt(s)));
+    const size_t s = data.size();
+    const auto s_sqrt = static_cast<size_t>(std::floor(std::sqrt(s)));
 
-  if (s < 4) {
-    throw std::invalid_argument("The dataset must be at least 2x2");
-  }
-  if (((s == 0) || (s & (s - 1)))) {
-    throw std::invalid_argument("The dataset must be a power of 2");
-  }
-  if (s_sqrt * s_sqrt != s) {
-    throw std::invalid_argument("The dataset must be a perfect square");
-  }
+    if (s < 4) {
+        throw std::invalid_argument("The dataset must be at least 2x2");
+    }
+    if (((s == 0) || (s & (s - 1)))) {
+        throw std::invalid_argument("The dataset must be a power of 2");
+    }
+    if (s_sqrt * s_sqrt != s) {
+        throw std::invalid_argument("The dataset must be a perfect square");
+    }
 
-  return static_cast<size_t>(log2(s_sqrt));
+    return static_cast<size_t>(log2(s_sqrt));
 }
 
 /**
@@ -292,15 +293,15 @@ template <class T> inline auto dimSize(const std::vector<T> &data) -> size_t {
 template <class T>
 inline auto operator<<(std::ostream &os, const std::vector<T> &vec)
     -> std::ostream & {
-  os << '[';
-  if (!vec.empty()) {
-    for (size_t i = 0; i < vec.size() - 1; i++) {
-      os << vec[i] << ", ";
+    os << '[';
+    if (!vec.empty()) {
+        for (size_t i = 0; i < vec.size() - 1; i++) {
+            os << vec[i] << ", ";
+        }
+        os << vec.back();
     }
-    os << vec.back();
-  }
-  os << ']';
-  return os;
+    os << ']';
+    return os;
 }
 
 /**
@@ -314,12 +315,12 @@ inline auto operator<<(std::ostream &os, const std::vector<T> &vec)
 template <class T>
 inline auto operator<<(std::ostream &os, const std::set<T> &s)
     -> std::ostream & {
-  os << '{';
-  for (const auto &e : s) {
-    os << e << ",";
-  }
-  os << '}';
-  return os;
+    os << '{';
+    for (const auto &e : s) {
+        os << e << ",";
+    }
+    os << '}';
+    return os;
 }
 
 /**
@@ -333,12 +334,12 @@ inline auto operator<<(std::ostream &os, const std::set<T> &s)
  */
 template <class T>
 auto linspace(T start, T end, size_t num_points) -> std::vector<T> {
-  std::vector<T> data(num_points);
-  T step = (end - start) / (num_points - 1);
-  for (size_t i = 0; i < num_points; i++) {
-    data[i] = start + (step * i);
-  }
-  return data;
+    std::vector<T> data(num_points);
+    T step = (end - start) / (num_points - 1);
+    for (size_t i = 0; i < num_points; i++) {
+        data[i] = start + (step * i);
+    }
+    return data;
 }
 
 /**
@@ -352,14 +353,14 @@ auto linspace(T start, T end, size_t num_points) -> std::vector<T> {
 template <typename T>
 inline auto sorting_indices(const T *arr, size_t length)
     -> std::vector<size_t> {
-  std::vector<size_t> indices(length);
-  iota(indices.begin(), indices.end(), 0);
+    std::vector<size_t> indices(length);
+    iota(indices.begin(), indices.end(), 0);
 
-  // indices will be sorted in accordance to the array provided.
-  sort(indices.begin(), indices.end(),
-       [&arr](size_t i1, size_t i2) { return arr[i1] < arr[i2]; });
+    // indices will be sorted in accordance to the array provided.
+    sort(indices.begin(), indices.end(),
+         [&arr](size_t i1, size_t i2) { return arr[i1] < arr[i2]; });
 
-  return indices;
+    return indices;
 }
 
 /**
@@ -371,7 +372,7 @@ inline auto sorting_indices(const T *arr, size_t length)
  */
 template <typename T>
 inline auto sorting_indices(const std::vector<T> &vec) -> std::vector<size_t> {
-  return sorting_indices(vec.data(), vec.size());
+    return sorting_indices(vec.data(), vec.size());
 }
 
 /**
@@ -385,12 +386,12 @@ inline auto sorting_indices(const std::vector<T> &vec) -> std::vector<size_t> {
 inline auto transposed_state_index(size_t ind,
                                    const std::vector<size_t> &new_axes)
     -> size_t {
-  size_t new_index = 0;
-  for (size_t axis : new_axes) {
-    new_index += (ind % 2) << axis;
-    ind /= 2;
-  }
-  return new_index;
+    size_t new_index = 0;
+    for (size_t axis : new_axes) {
+        new_index += (ind % 2) << axis;
+        ind /= 2;
+    }
+    return new_index;
 }
 
 /**
@@ -406,11 +407,11 @@ template <typename T>
 auto transpose_state_tensor(const std::vector<T> &tensor,
                             const std::vector<size_t> &new_axes)
     -> std::vector<T> {
-  std::vector<T> transposed_tensor(tensor.size());
-  for (size_t ind = 0; ind < tensor.size(); ind++) {
-    transposed_tensor[transposed_state_index(ind, new_axes)] = tensor[ind];
-  }
-  return transposed_tensor;
+    std::vector<T> transposed_tensor(tensor.size());
+    for (size_t ind = 0; ind < tensor.size(); ind++) {
+        transposed_tensor[transposed_state_index(ind, new_axes)] = tensor[ind];
+    }
+    return transposed_tensor;
 }
 
 /**
@@ -418,15 +419,15 @@ auto transpose_state_tensor(const std::vector<T> &tensor,
  *
  */
 class NotImplementedException : public std::logic_error {
-public:
-  /**
-   * @brief Construct a NotImplementedException exception object.
-   *
-   * @param fname Function name to indicate not implemented.
-   */
-  explicit NotImplementedException(const std::string &fname)
-      : std::logic_error(std::string("Function is not implemented. ") +
-                         fname){};
+  public:
+    /**
+     * @brief Construct a NotImplementedException exception object.
+     *
+     * @param fname Function name to indicate not implemented.
+     */
+    explicit NotImplementedException(const std::string &fname)
+        : std::logic_error(std::string("Function is not implemented. ") +
+                           fname){};
 };
 
 /**
@@ -442,12 +443,12 @@ public:
 template <template <typename...> class Container, typename T>
 auto chunkDataSize(const Container<T> &data, std::size_t chunk_size)
     -> Container<Container<T>> {
-  Container<Container<T>> output;
-  for (std::size_t chunk = 0; chunk < data.size(); chunk += chunk_size) {
-    const auto chunk_end = std::min(data.size(), chunk + chunk_size);
-    output.emplace_back(data.begin() + chunk, data.begin() + chunk_end);
-  }
-  return output;
+    Container<Container<T>> output;
+    for (std::size_t chunk = 0; chunk < data.size(); chunk += chunk_size) {
+        const auto chunk_end = std::min(data.size(), chunk + chunk_size);
+        output.emplace_back(data.begin() + chunk, data.begin() + chunk_end);
+    }
+    return output;
 }
 
 /** Chunk the data into the requested number of chunks */
@@ -464,40 +465,40 @@ auto chunkDataSize(const Container<T> &data, std::size_t chunk_size)
 template <template <typename...> class Container, typename T>
 auto chunkData(const Container<T> &data, std::size_t num_chunks)
     -> Container<Container<T>> {
-  const auto rem = data.size() % num_chunks;
-  const auto div = static_cast<std::size_t>(data.size() / num_chunks);
-  if (!div) { // Match chunks to available work
-    return chunkDataSize(data, 1);
-  }
-  if (rem) { // We have an uneven split; ensure fair distribution
-    auto output =
-        chunkDataSize(Container<T>{data.begin(), data.end() - rem}, div);
-    auto output_rem =
-        chunkDataSize(Container<T>{data.end() - rem, data.end()}, div);
-    for (std::size_t idx = 0; idx < output_rem.size(); idx++) {
-      output[idx].insert(output[idx].end(), output_rem[idx].begin(),
-                         output_rem[idx].end());
+    const auto rem = data.size() % num_chunks;
+    const auto div = static_cast<std::size_t>(data.size() / num_chunks);
+    if (!div) { // Match chunks to available work
+        return chunkDataSize(data, 1);
     }
-    return output;
-  }
-  return chunkDataSize(data, div);
+    if (rem) { // We have an uneven split; ensure fair distribution
+        auto output =
+            chunkDataSize(Container<T>{data.begin(), data.end() - rem}, div);
+        auto output_rem =
+            chunkDataSize(Container<T>{data.end() - rem, data.end()}, div);
+        for (std::size_t idx = 0; idx < output_rem.size(); idx++) {
+            output[idx].insert(output[idx].end(), output_rem[idx].begin(),
+                               output_rem[idx].end());
+        }
+        return output;
+    }
+    return chunkDataSize(data, div);
 }
 
 /**
  * @brief Define a hash function for std::pair
  */
 struct PairHash {
-  /**
-   * @brief A hash function for std::pair
-   *
-   * @tparam T The type of the first element of the pair
-   * @tparam U The type of the first element of the pair
-   * @param p A pair to compute hash
-   */
-  template <typename T, typename U>
-  size_t operator()(const std::pair<T, U> &p) const {
-    return std::hash<T>()(p.first) ^ std::hash<U>()(p.second);
-  }
+    /**
+     * @brief A hash function for std::pair
+     *
+     * @tparam T The type of the first element of the pair
+     * @tparam U The type of the first element of the pair
+     * @param p A pair to compute hash
+     */
+    template <typename T, typename U>
+    size_t operator()(const std::pair<T, U> &p) const {
+        return std::hash<T>()(p.first) ^ std::hash<U>()(p.second);
+    }
 };
 
 /**
@@ -507,19 +508,19 @@ struct PairHash {
  * @tparam Func function to execute
  */
 template <class T, class Func> void for_each_enum(Func &&func) {
-  for (auto e = T::BEGIN; e != T::END;
-       e = static_cast<T>(std::underlying_type_t<T>(e) + 1)) {
-    func(e);
-  }
+    for (auto e = T::BEGIN; e != T::END;
+         e = static_cast<T>(std::underlying_type_t<T>(e) + 1)) {
+        func(e);
+    }
 }
 template <class T, class U, class Func> void for_each_enum(Func &&func) {
-  for (auto e1 = T::BEGIN; e1 != T::END;
-       e1 = static_cast<T>(std::underlying_type_t<T>(e1) + 1)) {
-    for (auto e2 = U::BEGIN; e2 != U::END;
-         e2 = static_cast<U>(std::underlying_type_t<U>(e2) + 1)) {
-      func(e1, e2);
+    for (auto e1 = T::BEGIN; e1 != T::END;
+         e1 = static_cast<T>(std::underlying_type_t<T>(e1) + 1)) {
+        for (auto e2 = U::BEGIN; e2 != U::END;
+             e2 = static_cast<U>(std::underlying_type_t<U>(e2) + 1)) {
+            func(e1, e2);
+        }
     }
-  }
 }
 
 /**
@@ -536,21 +537,21 @@ template <class T, class U, class Func> void for_each_enum(Func &&func) {
 inline auto
 getIndicesAfterExclusion(const std::vector<size_t> &indicesToExclude,
                          size_t num_qubits) -> std::vector<size_t> {
-  std::vector<size_t> indices;
-  for (size_t i = 0; i < num_qubits; i++) {
-    indices.emplace_back(i);
-  }
-
-  for (size_t j = 0; j < indicesToExclude.size(); j++) {
-
-    const size_t excludedIndex = indicesToExclude[j];
-
-    for (size_t i = 0; i < indices.size(); i++) {
-      if (excludedIndex == indices[i])
-        indices.erase(indices.begin() + i);
+    std::vector<size_t> indices;
+    for (size_t i = 0; i < num_qubits; i++) {
+        indices.emplace_back(i);
     }
-  }
-  return indices;
+
+    for (size_t j = 0; j < indicesToExclude.size(); j++) {
+
+        const size_t excludedIndex = indicesToExclude[j];
+
+        for (size_t i = 0; i < indices.size(); i++) {
+            if (excludedIndex == indices[i])
+                indices.erase(indices.begin() + i);
+        }
+    }
+    return indices;
 }
 
 /**
@@ -567,20 +568,21 @@ getIndicesAfterExclusion(const std::vector<size_t> &indicesToExclude,
 inline auto generateBitsPatterns(const std::vector<size_t> &qubitIndices,
                                  size_t num_qubits) -> std::vector<size_t> {
 
-  std::vector<size_t> indices;
-  indices.reserve(exp2(qubitIndices.size()));
-  indices.emplace_back(0);
+    std::vector<size_t> indices;
+    indices.reserve(exp2(qubitIndices.size()));
+    indices.emplace_back(0);
 
-  for (size_t index_it0 = 0; index_it0 < qubitIndices.size(); index_it0++) {
-    size_t index_it = qubitIndices.size() - 1 - index_it0;
-    const size_t value = maxDecimalForQubit(qubitIndices[index_it], num_qubits);
+    for (size_t index_it0 = 0; index_it0 < qubitIndices.size(); index_it0++) {
+        size_t index_it = qubitIndices.size() - 1 - index_it0;
+        const size_t value =
+            maxDecimalForQubit(qubitIndices[index_it], num_qubits);
 
-    const size_t currentSize = indices.size();
-    for (size_t j = 0; j < currentSize; j++) {
-      indices.emplace_back(indices[j] + value);
+        const size_t currentSize = indices.size();
+        for (size_t j = 0; j < currentSize; j++) {
+            indices.emplace_back(indices[j] + value);
+        }
     }
-  }
-  return indices;
+    return indices;
 }
 
 /**
@@ -593,17 +595,17 @@ inline auto generateBitsPatterns(const std::vector<size_t> &qubitIndices,
 inline auto operator<<(std::ostream &os,
                        const Kokkos::InitializationSettings &args)
     -> std::ostream & {
-  os << "InitializationSettings:\n";
-  os << "num_threads = " << args.get_num_threads() << '\n';
-  os << "device_id = " << args.get_device_id() << '\n';
-  os << "map_device_id_by = " << args.get_map_device_id_by() << '\n';
-  os << "disable_warnings = " << args.get_disable_warnings() << '\n';
-  os << "print_configuration = " << args.get_print_configuration() << '\n';
-  os << "tune_internals = " << args.get_tune_internals() << '\n';
-  os << "tools_libs = " << args.get_tools_libs() << '\n';
-  os << "tools_help = " << args.get_tools_help() << '\n';
-  os << "tools_args = " << args.get_tools_args();
-  return os;
+    os << "InitializationSettings:\n";
+    os << "num_threads = " << args.get_num_threads() << '\n';
+    os << "device_id = " << args.get_device_id() << '\n';
+    os << "map_device_id_by = " << args.get_map_device_id_by() << '\n';
+    os << "disable_warnings = " << args.get_disable_warnings() << '\n';
+    os << "print_configuration = " << args.get_print_configuration() << '\n';
+    os << "tune_internals = " << args.get_tune_internals() << '\n';
+    os << "tools_libs = " << args.get_tools_libs() << '\n';
+    os << "tools_help = " << args.get_tools_help() << '\n';
+    os << "tools_args = " << args.get_tools_args();
+    return os;
 }
 
 } // namespace Pennylane::Util

--- a/pennylane_lightning_kokkos/src/util/Util.hpp
+++ b/pennylane_lightning_kokkos/src/util/Util.hpp
@@ -46,7 +46,7 @@
 namespace Pennylane::Util {
 template <typename T> struct remove_complex { using type = T; };
 template <typename T> struct remove_complex<std::complex<T>> {
-    using type = T;
+  using type = T;
 };
 template <typename T> using remove_complex_t = typename remove_complex<T>::type;
 
@@ -60,27 +60,26 @@ template <typename T> constexpr bool is_complex_v = is_complex<T>::value;
  * Utility hash function for complex vectors representing matrices.
  */
 struct MatrixHasher {
-    template <class Precision = double>
-    std::size_t
-    operator()(const std::vector<std::complex<Precision>> &matrix) const {
-        std::size_t hash_val = matrix.size();
-        for (const auto &c_val : matrix) {
-            hash_val ^= std::hash<Precision>()(c_val.real()) ^
-                        std::hash<Precision>()(c_val.imag());
-        }
-        return hash_val;
+  template <class Precision = double>
+  std::size_t
+  operator()(const std::vector<std::complex<Precision>> &matrix) const {
+    std::size_t hash_val = matrix.size();
+    for (const auto &c_val : matrix) {
+      hash_val ^= std::hash<Precision>()(c_val.real()) ^
+                  std::hash<Precision>()(c_val.imag());
     }
+    return hash_val;
+  }
 };
 
 struct BitSwapFunctor {
-    BitSwapFunctor() = default;
+  BitSwapFunctor() = default;
 
-    KOKKOS_INLINE_FUNCTION
-    std::size_t operator()(const size_t &bits, const size_t &i,
-                           const size_t &j) {
-        size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
-        return bits ^ ((x << i) | (x << j));
-    }
+  KOKKOS_INLINE_FUNCTION
+  std::size_t operator()(const size_t &bits, const size_t &i, const size_t &j) {
+    size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
+    return bits ^ ((x << i) | (x << j));
+  }
 };
 
 /**
@@ -88,22 +87,22 @@ struct BitSwapFunctor {
  */
 inline auto constexpr bitswap(size_t bits, const size_t i, const size_t j)
     -> size_t {
-    size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
-    return bits ^ ((x << i) | (x << j));
+  size_t x = ((bits >> i) ^ (bits >> j)) & 1U;
+  return bits ^ ((x << i) | (x << j));
 }
 
 /**
  * @brief Fill ones from LSB to rev_wire
  */
 inline size_t fillTrailingOnes(size_t pos) {
-    return (pos == 0) ? 0 : (~size_t(0) >> (CHAR_BIT * sizeof(size_t) - pos));
+  return (pos == 0) ? 0 : (~size_t(0) >> (CHAR_BIT * sizeof(size_t) - pos));
 }
 
 /**
  * @brief Fill ones from MSB to pos
  */
 inline auto constexpr fillLeadingOnes(size_t pos) -> size_t {
-    return (~size_t(0)) << pos;
+  return (~size_t(0)) << pos;
 }
 
 /**
@@ -118,7 +117,7 @@ inline auto constexpr fillLeadingOnes(size_t pos) -> size_t {
 template <class T, class U = T>
 inline static constexpr auto ConstMult(U a, std::complex<T> b)
     -> std::complex<T> {
-    return {a * b.real(), a * b.imag()};
+  return {a * b.real(), a * b.imag()};
 }
 
 /**
@@ -133,14 +132,14 @@ inline static constexpr auto ConstMult(U a, std::complex<T> b)
 template <class T, class U = T>
 inline static constexpr auto ConstMult(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-    return {a.real() * b.real() - a.imag() * b.imag(),
-            a.real() * b.imag() + a.imag() * b.real()};
+  return {a.real() * b.real() - a.imag() * b.imag(),
+          a.real() * b.imag() + a.imag() * b.real()};
 }
 template <class T, class U = T>
 inline static constexpr auto ConstMultConj(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-    return {a.real() * b.real() + a.imag() * b.imag(),
-            -a.imag() * b.real() + a.real() * b.imag()};
+  return {a.real() * b.real() + a.imag() * b.imag(),
+          -a.imag() * b.real() + a.real() * b.imag()};
 }
 
 /**
@@ -155,7 +154,7 @@ inline static constexpr auto ConstMultConj(std::complex<U> a, std::complex<T> b)
 template <class T, class U = T>
 inline static constexpr auto ConstSum(std::complex<U> a, std::complex<T> b)
     -> std::complex<T> {
-    return a + b;
+  return a + b;
 }
 
 /**
@@ -166,7 +165,7 @@ inline static constexpr auto ConstSum(std::complex<U> a, std::complex<T> b)
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto ONE() -> ComplexT<T> {
-    return {1, 0};
+  return {1, 0};
 }
 
 /**
@@ -177,7 +176,7 @@ inline static constexpr auto ONE() -> ComplexT<T> {
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto ZERO() -> ComplexT<T> {
-    return {0, 0};
+  return {0, 0};
 }
 
 /**
@@ -188,17 +187,17 @@ inline static constexpr auto ZERO() -> ComplexT<T> {
  */
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto IMAG() -> ComplexT<T> {
-    return {0, 1};
+  return {0, 1};
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto HALF() -> ComplexT<T> {
-    return {0.5, 0};
+  return {0.5, 0};
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto NEGONE() -> ComplexT<T> {
-    return {-1, 0};
+  return {-1, 0};
 }
 
 /**
@@ -210,19 +209,19 @@ inline static constexpr auto NEGONE() -> ComplexT<T> {
 template <template <typename...> class ComplexT, typename T>
 inline static constexpr auto SQRT2() -> ComplexT<T> {
 #if __cpp_lib_math_constants >= 201907L
-    return std::numbers::sqrt2_v<T>;
+  return std::numbers::sqrt2_v<T>;
 #else
-    if constexpr (std::is_same_v<T, float>) {
-        return {0x1.6a09e6p+0F, 0}; // NOLINT: To be replaced in C++20
-    } else {
-        return {0x1.6a09e667f3bcdp+0, 0}; // NOLINT: To be replaced in C++20
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return {0x1.6a09e6p+0F, 0}; // NOLINT: To be replaced in C++20
+  } else {
+    return {0x1.6a09e667f3bcdp+0, 0}; // NOLINT: To be replaced in C++20
+  }
 #endif
 }
 
 template <template <typename...> class ComplexT, typename T>
 inline constexpr auto INVSQRT2() -> ComplexT<T> {
-    return {1 / real(SQRT2<ComplexT, T>()), 0};
+  return {1 / real(SQRT2<ComplexT, T>()), 0};
 }
 
 /**
@@ -232,7 +231,7 @@ inline constexpr auto INVSQRT2() -> ComplexT<T> {
  * @return value of 2^n
  */
 inline auto exp2(const size_t &n) -> size_t {
-    return static_cast<size_t>(1) << n;
+  return static_cast<size_t>(1) << n;
 }
 
 /**
@@ -242,7 +241,7 @@ inline auto exp2(const size_t &n) -> size_t {
  * @return size_t
  */
 inline auto log2(size_t value) -> size_t {
-    return static_cast<size_t>(std::log2(value));
+  return static_cast<size_t>(std::log2(value));
 }
 
 /**
@@ -254,8 +253,8 @@ inline auto log2(size_t value) -> size_t {
  * @return decimal value for the qubit at specified index
  */
 inline auto maxDecimalForQubit(size_t qubitIndex, size_t qubits) -> size_t {
-    assert(qubitIndex < qubits);
-    return exp2(qubits - qubitIndex - 1);
+  assert(qubitIndex < qubits);
+  return exp2(qubits - qubitIndex - 1);
 }
 
 /**
@@ -266,20 +265,20 @@ inline auto maxDecimalForQubit(size_t qubitIndex, size_t qubits) -> size_t {
  * @return size_t Number of wires.
  */
 template <class T> inline auto dimSize(const std::vector<T> &data) -> size_t {
-    const size_t s = data.size();
-    const auto s_sqrt = static_cast<size_t>(std::floor(std::sqrt(s)));
+  const size_t s = data.size();
+  const auto s_sqrt = static_cast<size_t>(std::floor(std::sqrt(s)));
 
-    if (s < 4) {
-        throw std::invalid_argument("The dataset must be at least 2x2");
-    }
-    if (((s == 0) || (s & (s - 1)))) {
-        throw std::invalid_argument("The dataset must be a power of 2");
-    }
-    if (s_sqrt * s_sqrt != s) {
-        throw std::invalid_argument("The dataset must be a perfect square");
-    }
+  if (s < 4) {
+    throw std::invalid_argument("The dataset must be at least 2x2");
+  }
+  if (((s == 0) || (s & (s - 1)))) {
+    throw std::invalid_argument("The dataset must be a power of 2");
+  }
+  if (s_sqrt * s_sqrt != s) {
+    throw std::invalid_argument("The dataset must be a perfect square");
+  }
 
-    return static_cast<size_t>(log2(s_sqrt));
+  return static_cast<size_t>(log2(s_sqrt));
 }
 
 /**
@@ -293,15 +292,15 @@ template <class T> inline auto dimSize(const std::vector<T> &data) -> size_t {
 template <class T>
 inline auto operator<<(std::ostream &os, const std::vector<T> &vec)
     -> std::ostream & {
-    os << '[';
-    if (!vec.empty()) {
-        for (size_t i = 0; i < vec.size() - 1; i++) {
-            os << vec[i] << ", ";
-        }
-        os << vec.back();
+  os << '[';
+  if (!vec.empty()) {
+    for (size_t i = 0; i < vec.size() - 1; i++) {
+      os << vec[i] << ", ";
     }
-    os << ']';
-    return os;
+    os << vec.back();
+  }
+  os << ']';
+  return os;
 }
 
 /**
@@ -315,12 +314,12 @@ inline auto operator<<(std::ostream &os, const std::vector<T> &vec)
 template <class T>
 inline auto operator<<(std::ostream &os, const std::set<T> &s)
     -> std::ostream & {
-    os << '{';
-    for (const auto &e : s) {
-        os << e << ",";
-    }
-    os << '}';
-    return os;
+  os << '{';
+  for (const auto &e : s) {
+    os << e << ",";
+  }
+  os << '}';
+  return os;
 }
 
 /**
@@ -334,12 +333,12 @@ inline auto operator<<(std::ostream &os, const std::set<T> &s)
  */
 template <class T>
 auto linspace(T start, T end, size_t num_points) -> std::vector<T> {
-    std::vector<T> data(num_points);
-    T step = (end - start) / (num_points - 1);
-    for (size_t i = 0; i < num_points; i++) {
-        data[i] = start + (step * i);
-    }
-    return data;
+  std::vector<T> data(num_points);
+  T step = (end - start) / (num_points - 1);
+  for (size_t i = 0; i < num_points; i++) {
+    data[i] = start + (step * i);
+  }
+  return data;
 }
 
 /**
@@ -353,14 +352,14 @@ auto linspace(T start, T end, size_t num_points) -> std::vector<T> {
 template <typename T>
 inline auto sorting_indices(const T *arr, size_t length)
     -> std::vector<size_t> {
-    std::vector<size_t> indices(length);
-    iota(indices.begin(), indices.end(), 0);
+  std::vector<size_t> indices(length);
+  iota(indices.begin(), indices.end(), 0);
 
-    // indices will be sorted in accordance to the array provided.
-    sort(indices.begin(), indices.end(),
-         [&arr](size_t i1, size_t i2) { return arr[i1] < arr[i2]; });
+  // indices will be sorted in accordance to the array provided.
+  sort(indices.begin(), indices.end(),
+       [&arr](size_t i1, size_t i2) { return arr[i1] < arr[i2]; });
 
-    return indices;
+  return indices;
 }
 
 /**
@@ -372,7 +371,7 @@ inline auto sorting_indices(const T *arr, size_t length)
  */
 template <typename T>
 inline auto sorting_indices(const std::vector<T> &vec) -> std::vector<size_t> {
-    return sorting_indices(vec.data(), vec.size());
+  return sorting_indices(vec.data(), vec.size());
 }
 
 /**
@@ -386,12 +385,12 @@ inline auto sorting_indices(const std::vector<T> &vec) -> std::vector<size_t> {
 inline auto transposed_state_index(size_t ind,
                                    const std::vector<size_t> &new_axes)
     -> size_t {
-    size_t new_index = 0;
-    for (size_t axis : new_axes) {
-        new_index += (ind % 2) << axis;
-        ind /= 2;
-    }
-    return new_index;
+  size_t new_index = 0;
+  for (size_t axis : new_axes) {
+    new_index += (ind % 2) << axis;
+    ind /= 2;
+  }
+  return new_index;
 }
 
 /**
@@ -407,11 +406,11 @@ template <typename T>
 auto transpose_state_tensor(const std::vector<T> &tensor,
                             const std::vector<size_t> &new_axes)
     -> std::vector<T> {
-    std::vector<T> transposed_tensor(tensor.size());
-    for (size_t ind = 0; ind < tensor.size(); ind++) {
-        transposed_tensor[transposed_state_index(ind, new_axes)] = tensor[ind];
-    }
-    return transposed_tensor;
+  std::vector<T> transposed_tensor(tensor.size());
+  for (size_t ind = 0; ind < tensor.size(); ind++) {
+    transposed_tensor[transposed_state_index(ind, new_axes)] = tensor[ind];
+  }
+  return transposed_tensor;
 }
 
 /**
@@ -419,15 +418,15 @@ auto transpose_state_tensor(const std::vector<T> &tensor,
  *
  */
 class NotImplementedException : public std::logic_error {
-  public:
-    /**
-     * @brief Construct a NotImplementedException exception object.
-     *
-     * @param fname Function name to indicate not implemented.
-     */
-    explicit NotImplementedException(const std::string &fname)
-        : std::logic_error(std::string("Function is not implemented. ") +
-                           fname){};
+public:
+  /**
+   * @brief Construct a NotImplementedException exception object.
+   *
+   * @param fname Function name to indicate not implemented.
+   */
+  explicit NotImplementedException(const std::string &fname)
+      : std::logic_error(std::string("Function is not implemented. ") +
+                         fname){};
 };
 
 /**
@@ -443,12 +442,12 @@ class NotImplementedException : public std::logic_error {
 template <template <typename...> class Container, typename T>
 auto chunkDataSize(const Container<T> &data, std::size_t chunk_size)
     -> Container<Container<T>> {
-    Container<Container<T>> output;
-    for (std::size_t chunk = 0; chunk < data.size(); chunk += chunk_size) {
-        const auto chunk_end = std::min(data.size(), chunk + chunk_size);
-        output.emplace_back(data.begin() + chunk, data.begin() + chunk_end);
-    }
-    return output;
+  Container<Container<T>> output;
+  for (std::size_t chunk = 0; chunk < data.size(); chunk += chunk_size) {
+    const auto chunk_end = std::min(data.size(), chunk + chunk_size);
+    output.emplace_back(data.begin() + chunk, data.begin() + chunk_end);
+  }
+  return output;
 }
 
 /** Chunk the data into the requested number of chunks */
@@ -465,40 +464,40 @@ auto chunkDataSize(const Container<T> &data, std::size_t chunk_size)
 template <template <typename...> class Container, typename T>
 auto chunkData(const Container<T> &data, std::size_t num_chunks)
     -> Container<Container<T>> {
-    const auto rem = data.size() % num_chunks;
-    const auto div = static_cast<std::size_t>(data.size() / num_chunks);
-    if (!div) { // Match chunks to available work
-        return chunkDataSize(data, 1);
+  const auto rem = data.size() % num_chunks;
+  const auto div = static_cast<std::size_t>(data.size() / num_chunks);
+  if (!div) { // Match chunks to available work
+    return chunkDataSize(data, 1);
+  }
+  if (rem) { // We have an uneven split; ensure fair distribution
+    auto output =
+        chunkDataSize(Container<T>{data.begin(), data.end() - rem}, div);
+    auto output_rem =
+        chunkDataSize(Container<T>{data.end() - rem, data.end()}, div);
+    for (std::size_t idx = 0; idx < output_rem.size(); idx++) {
+      output[idx].insert(output[idx].end(), output_rem[idx].begin(),
+                         output_rem[idx].end());
     }
-    if (rem) { // We have an uneven split; ensure fair distribution
-        auto output =
-            chunkDataSize(Container<T>{data.begin(), data.end() - rem}, div);
-        auto output_rem =
-            chunkDataSize(Container<T>{data.end() - rem, data.end()}, div);
-        for (std::size_t idx = 0; idx < output_rem.size(); idx++) {
-            output[idx].insert(output[idx].end(), output_rem[idx].begin(),
-                               output_rem[idx].end());
-        }
-        return output;
-    }
-    return chunkDataSize(data, div);
+    return output;
+  }
+  return chunkDataSize(data, div);
 }
 
 /**
  * @brief Define a hash function for std::pair
  */
 struct PairHash {
-    /**
-     * @brief A hash function for std::pair
-     *
-     * @tparam T The type of the first element of the pair
-     * @tparam U The type of the first element of the pair
-     * @param p A pair to compute hash
-     */
-    template <typename T, typename U>
-    size_t operator()(const std::pair<T, U> &p) const {
-        return std::hash<T>()(p.first) ^ std::hash<U>()(p.second);
-    }
+  /**
+   * @brief A hash function for std::pair
+   *
+   * @tparam T The type of the first element of the pair
+   * @tparam U The type of the first element of the pair
+   * @param p A pair to compute hash
+   */
+  template <typename T, typename U>
+  size_t operator()(const std::pair<T, U> &p) const {
+    return std::hash<T>()(p.first) ^ std::hash<U>()(p.second);
+  }
 };
 
 /**
@@ -508,19 +507,19 @@ struct PairHash {
  * @tparam Func function to execute
  */
 template <class T, class Func> void for_each_enum(Func &&func) {
-    for (auto e = T::BEGIN; e != T::END;
-         e = static_cast<T>(std::underlying_type_t<T>(e) + 1)) {
-        func(e);
-    }
+  for (auto e = T::BEGIN; e != T::END;
+       e = static_cast<T>(std::underlying_type_t<T>(e) + 1)) {
+    func(e);
+  }
 }
 template <class T, class U, class Func> void for_each_enum(Func &&func) {
-    for (auto e1 = T::BEGIN; e1 != T::END;
-         e1 = static_cast<T>(std::underlying_type_t<T>(e1) + 1)) {
-        for (auto e2 = U::BEGIN; e2 != U::END;
-             e2 = static_cast<U>(std::underlying_type_t<U>(e2) + 1)) {
-            func(e1, e2);
-        }
+  for (auto e1 = T::BEGIN; e1 != T::END;
+       e1 = static_cast<T>(std::underlying_type_t<T>(e1) + 1)) {
+    for (auto e2 = U::BEGIN; e2 != U::END;
+         e2 = static_cast<U>(std::underlying_type_t<U>(e2) + 1)) {
+      func(e1, e2);
     }
+  }
 }
 
 /**
@@ -537,21 +536,21 @@ template <class T, class U, class Func> void for_each_enum(Func &&func) {
 inline auto
 getIndicesAfterExclusion(const std::vector<size_t> &indicesToExclude,
                          size_t num_qubits) -> std::vector<size_t> {
-    std::vector<size_t> indices;
-    for (size_t i = 0; i < num_qubits; i++) {
-        indices.emplace_back(i);
+  std::vector<size_t> indices;
+  for (size_t i = 0; i < num_qubits; i++) {
+    indices.emplace_back(i);
+  }
+
+  for (size_t j = 0; j < indicesToExclude.size(); j++) {
+
+    const size_t excludedIndex = indicesToExclude[j];
+
+    for (size_t i = 0; i < indices.size(); i++) {
+      if (excludedIndex == indices[i])
+        indices.erase(indices.begin() + i);
     }
-
-    for (size_t j = 0; j < indicesToExclude.size(); j++) {
-
-        const size_t excludedIndex = indicesToExclude[j];
-
-        for (size_t i = 0; i < indices.size(); i++) {
-            if (excludedIndex == indices[i])
-                indices.erase(indices.begin() + i);
-        }
-    }
-    return indices;
+  }
+  return indices;
 }
 
 /**
@@ -568,40 +567,43 @@ getIndicesAfterExclusion(const std::vector<size_t> &indicesToExclude,
 inline auto generateBitsPatterns(const std::vector<size_t> &qubitIndices,
                                  size_t num_qubits) -> std::vector<size_t> {
 
-    std::vector<size_t> indices;
-    indices.reserve(exp2(qubitIndices.size()));
-    indices.emplace_back(0);
+  std::vector<size_t> indices;
+  indices.reserve(exp2(qubitIndices.size()));
+  indices.emplace_back(0);
 
-    for (size_t index_it0 = 0; index_it0 < qubitIndices.size(); index_it0++) {
-        size_t index_it = qubitIndices.size() - 1 - index_it0;
-        const size_t value =
-            maxDecimalForQubit(qubitIndices[index_it], num_qubits);
+  for (size_t index_it0 = 0; index_it0 < qubitIndices.size(); index_it0++) {
+    size_t index_it = qubitIndices.size() - 1 - index_it0;
+    const size_t value = maxDecimalForQubit(qubitIndices[index_it], num_qubits);
 
-        const size_t currentSize = indices.size();
-        for (size_t j = 0; j < currentSize; j++) {
-            indices.emplace_back(indices[j] + value);
-        }
+    const size_t currentSize = indices.size();
+    for (size_t j = 0; j < currentSize; j++) {
+      indices.emplace_back(indices[j] + value);
     }
-    return indices;
+  }
+  return indices;
 }
 
 /**
- * @brief Streaming operator for Kokkos::InitArguments structs.
+ * @brief Streaming operator for Kokkos::InitializationSettings objects.
  *
  * @param os Output stream.
- * @param args Kokkos::InitArguments struct.
+ * @param args Kokkos::InitializationSettings object.
  * @return std::ostream&
  */
-inline auto operator<<(std::ostream &os, const Kokkos::InitArguments &args)
+inline auto operator<<(std::ostream &os,
+                       const Kokkos::InitializationSettings &args)
     -> std::ostream & {
-    os << "<InitArguments with\n";
-    os << "num_threads = " << args.num_threads << '\n';
-    os << "num_numa = " << args.num_numa << '\n';
-    os << "device_id = " << args.device_id << '\n';
-    os << "ndevices = " << args.ndevices << '\n';
-    os << "skip_device = " << args.skip_device << '\n';
-    os << "disable_warnings = " << args.disable_warnings << ">";
-    return os;
+  os << "InitializationSettings:\n";
+  os << "num_threads = " << args.get_num_threads() << '\n';
+  os << "device_id = " << args.get_device_id() << '\n';
+  os << "map_device_id_by = " << args.get_map_device_id_by() << '\n';
+  os << "disable_warnings = " << args.get_disable_warnings() << '\n';
+  os << "print_configuration = " << args.get_print_configuration() << '\n';
+  os << "tune_internals = " << args.get_tune_internals() << '\n';
+  os << "tools_libs = " << args.get_tools_libs() << '\n';
+  os << "tools_help = " << args.get_tools_help() << '\n';
+  os << "tools_args = " << args.get_tools_args();
+  return os;
 }
 
 } // namespace Pennylane::Util

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -22,7 +22,7 @@ from pennylane import numpy as np
 from pennylane import QNode, qnode
 from scipy.stats import unitary_group
 import pennylane_lightning_kokkos as plk
-from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import InitArguments
+from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import InitializationSettings
 
 from pennylane import (
     QuantumFunctionError,
@@ -76,7 +76,7 @@ class TestAdjointJacobian:
     from pennylane_lightning_kokkos import LightningKokkos as lk
     from pennylane_lightning import LightningQubit as lq
 
-    @pytest.fixture(params=[None, InitArguments(2)])
+    @pytest.fixture(params=[None, InitializationSettings().set_num_threads(2)])
     def dev_kokkos(self, request):
         if request.param is None:
             return qml.device("lightning.kokkos", wires=3)

--- a/tests/test_kokkos_utils.py
+++ b/tests/test_kokkos_utils.py
@@ -16,49 +16,49 @@ Unit tests for Kokkos bindings.
 """
 import pytest
 
-from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import InitArguments
+from pennylane_lightning_kokkos.lightning_kokkos_qubit_ops import InitializationSettings
 
 
 class TestKokkos:
     """Tests that Kokkos bindings work."""
 
-    @pytest.mark.parametrize("init_threads", [None, 1, 2, 5])
     @pytest.mark.parametrize(
         "fields",
         [
-            ("num_threads", -1, 2),
-            ("num_numa", -1, 3),
-            ("device_id", -1, 4),
-            ("ndevices", -1, 5),
-            ("skip_device", 9999, 6),
-            ("disable_warnings", False, True),
+            ("get_num_threads", 0),
+            ("get_device_id", 0),
+            ("get_map_device_id_by", ""),
+            ("get_disable_warnings", 0),
+            ("get_print_configuration", 0),
+            ("get_tune_internals", 0),
+            ("get_tools_libs", ""),
+            ("get_tools_help", 0),
+            ("get_tools_args", ""),
         ],
     )
-    def test_InitArguments_readwrite_attrs(self, init_threads, fields):
-        """Tests that InitArguments fields are properly accessed."""
-        field, default, value = fields
-        if init_threads is None:
-            args = InitArguments()
-        else:
-            args = InitArguments(init_threads)
-            default = init_threads if field == "num_threads" else default
-        assert getattr(args, field) == default
-        setattr(args, field, value)
-        assert getattr(args, field) == value
+    def test_InitializationSettings_getters(self, fields):
+        """Tests that InitializationSettings fields are properly accessed."""
+        args = InitializationSettings()
+        field, default = fields
+        assert getattr(args, field)() == default
 
-    @pytest.mark.parametrize("init_threads", list(range(1, 5)))
-    def test_InitArguments_repr(self, init_threads):
-        """Tests that InitArguments are properly initialized."""
-        r0 = f"""<InitArguments with
-num_threads = {init_threads}
-num_numa = -1
-device_id = -1
-ndevices = -1
-skip_device = 9999
-disable_warnings = 0>"""
-        args = InitArguments()
-        r1 = args.__repr__()
-        assert r1.strip() != r0.strip()
-        args = InitArguments(init_threads)
-        r1 = args.__repr__()
-        assert r1.strip() == r0.strip()
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            ("num_threads", 4),
+            ("device_id", 1),
+            ("map_device_id_by", "mpi_rank"),
+            ("disable_warnings", True),
+            ("print_configuration", True),
+            ("tune_internals", True),
+            ("tools_libs", "LD_LIBRARY_PATH"),
+            ("tools_help", True),
+            ("tools_args", "TOOL_ARGS"),
+        ],
+    )
+    def test_InitializationSettings_setters(self, fields):
+        """Tests that InitializationSettings fields are properly accessed."""
+        args = InitializationSettings()
+        field, value = fields
+        _ = getattr(args, f"set_{field}")(value)
+        assert getattr(args, f"get_{field}")() == value


### PR DESCRIPTION
**Context:**
`Kokkos::InitArguments` will be deprecated. 

**Description of the Change:**
Replace `Kokkos::InitArguments` with `Kokkos::InitializationSettings`.
Add C++ bindings for `Kokkos::InitializationSettings` and `print_configuration`.

**Benefits:**
Keep up-to-date with latest Kokkos changes. No need to build Kokkos libs with deprecated code options.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
