### PR TITLE
Tentative alignment of setup.py with Conda-Forge

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Remove logic from `setup.py` and transfer paths and definitions into workflow files.
+[(#58)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/58)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Vincent Michaud-Rioux
 
 ---
 
@@ -29,9 +34,6 @@ This release contains contributions from (in alphabetical order):
 [(#49)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/49)
 
 ### Improvements
-
-* Remove logic from `setup.py` and transfer paths and definitions into workflow files.
-[(#58)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/58)
 
 * Remove deprecated `set-output` commands from workflow files.
 [(#56)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/56)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Improvements
 
+* Remove logic from `setup.py` and transfer paths and definitions into workflow files.
+[(#58)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/58)
+
 * Remove deprecated `set-output` commands from workflow files.
 [(#56)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/56)
 

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_OPENMP=ON
-          CC: $(which gcc-${{ env.GCC_VERSION }})
-          CXX: $(which g++-${{ env.GCC_VERSION }})
+          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
+          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -153,8 +153,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_SERIAL=ON
-          CC: $(which gcc-${{ env.GCC_VERSION }})
-          CXX: $(which g++-${{ env.GCC_VERSION }})
+          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
+          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -227,8 +227,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_THREADS=ON
-          CC: $(which gcc-${{ env.GCC_VERSION }})
-          CXX: $(which g++-${{ env.GCC_VERSION }})
+          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
+          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
         run: |
           cd main
           python -m pip install -e . --verbose

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install lightning.kokkos device
         env:
-          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_OPENMP=ON"
+          CMAKE_ARGS: -DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_OPENMP=ON
         run: |
           cd main
           python -m pip install -e . --verbose

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -37,11 +37,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
 
       - name: Build and run unit tests
+        env:
+          OMP_PROC_BIND: false
+          OMP_PLACES: threads
         run: |
             cmake . -BBuild -DKokkos_ENABLE_OPENMP=ON -DPLKOKKOS_BUILD_TESTS=ON -DPLKOKKOS_ENABLE_SANITIZER=ON -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})"
             cmake --build ./Build
-            export OMP_PROC_BIND=false
-            export OMP_PLACES=threads
             ./Build/pennylane_lightning_kokkos/src/tests/runner_kokkos
 
   pythontests_openmp:
@@ -84,6 +85,8 @@ jobs:
           python -m pip install -e . --verbose
           
       - name: Run PennyLane-Lightning-Kokkos unit tests
+        env:
+          OMP_PROC_BIND: false
         run: |
           cd main/
           pytest tests/
@@ -160,6 +163,8 @@ jobs:
           python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests
+        env:
+          OMP_PROC_BIND: false
         run: |
           cd main/
           pytest tests/
@@ -234,6 +239,8 @@ jobs:
           python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests
+        env:
+          OMP_PROC_BIND: false
         run: |
           cd main/
           pytest tests/

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_OPENMP=ON
-          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
-          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
+          CC: gcc-${{ env.GCC_VERSION }}
+          CXX: g++-${{ env.GCC_VERSION }}
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -153,8 +153,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_SERIAL=ON
-          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
-          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
+          CC: gcc-${{ env.GCC_VERSION }}
+          CXX: g++-${{ env.GCC_VERSION }}
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -227,8 +227,8 @@ jobs:
       - name: Install lightning.kokkos device
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_THREADS=ON
-          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
-          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
+          CC: gcc-${{ env.GCC_VERSION }}
+          CXX: g++-${{ env.GCC_VERSION }}
         run: |
           cd main
           python -m pip install -e . --verbose

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -75,7 +75,7 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
-        env: |
+        env:
           CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_OPENMP=ON"
         run: |
           cd main
@@ -149,7 +149,7 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
-        env: |
+        env:
           CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_SERIAL=ON"
         run: |
           cd main
@@ -221,7 +221,7 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
-        env: |
+        env:
           CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_THREADS=ON"
         run: |
           cd main

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Install lightning.kokkos device
         env:
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_OPENMP=ON
+          CMAKE_ARGS: -DKokkos_ENABLE_OPENMP=ON
+          CC: $(which gcc-${{ env.GCC_VERSION }})
+          CXX: $(which g++-${{ env.GCC_VERSION }})
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -150,7 +152,9 @@ jobs:
 
       - name: Install lightning.kokkos device
         env:
-          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_SERIAL=ON"
+          CMAKE_ARGS: -DKokkos_ENABLE_SERIAL=ON
+          CC: $(which gcc-${{ env.GCC_VERSION }})
+          CXX: $(which g++-${{ env.GCC_VERSION }})
         run: |
           cd main
           python -m pip install -e . --verbose
@@ -222,7 +226,9 @@ jobs:
 
       - name: Install lightning.kokkos device
         env:
-          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_THREADS=ON"
+          CMAKE_ARGS: -DKokkos_ENABLE_THREADS=ON
+          CC: $(which gcc-${{ env.GCC_VERSION }})
+          CXX: $(which g++-${{ env.GCC_VERSION }})
         run: |
           cd main
           python -m pip install -e . --verbose

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -43,6 +43,7 @@ jobs:
             export OMP_PROC_BIND=false
             export OMP_PLACES=threads
             ./Build/pennylane_lightning_kokkos/src/tests/runner_kokkos
+
   pythontests_openmp:
     name: Python tests for OpenMP Kokkos Backend
     runs-on: ${{ matrix.os }}
@@ -74,15 +75,19 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
+        env: |
+          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_OPENMP=ON"
         run: |
           cd main
-          CC=$(which gcc-${{ env.GCC_VERSION }}) CXX=$(which g++-${{ env.GCC_VERSION }}) BACKEND="OPENMP" python -m pip install -e . --verbose
+          python -m pip install -e . --verbose
+          
       - name: Run PennyLane-Lightning-Kokkos unit tests
         run: |
           cd main/
           pytest tests/
           pl-device-test --device lightning.kokkos --skip-ops --shots=20000
           pl-device-test --device lightning.kokkos --skip-ops --shots=None
+
   cpptests_serial:
     name: C++ tests (Linux) for Serial Kokkos backend
     runs-on: ${{ matrix.os }}
@@ -112,6 +117,7 @@ jobs:
             cmake . -BBuild -DPLKOKKOS_BUILD_TESTS=ON -DPLKOKKOS_ENABLE_SANITIZER=ON -DCMAKE_CXX_COMPILER="$(which g++-${{ env.GCC_VERSION }})"
             cmake --build ./Build
             ./Build/pennylane_lightning_kokkos/src/tests/runner_kokkos
+
   pythontests_serial:
     name: Python tests for Serial Kokkos Backend
     runs-on: ${{ matrix.os }}
@@ -143,9 +149,12 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
+        env: |
+          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_SERIAL=ON"
         run: |
           cd main
-          CC=$(which gcc-${{ env.GCC_VERSION }}) CXX=$(which g++-${{ env.GCC_VERSION }}) BACKEND="SERIAL" python -m pip install -e . --verbose
+          python -m pip install -e . --verbose
+
       - name: Run PennyLane-Lightning-Kokkos unit tests
         run: |
           cd main/
@@ -212,9 +221,12 @@ jobs:
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
+        env: |
+          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_THREADS=ON"
         run: |
           cd main
-          CC=$(which gcc-${{ env.GCC_VERSION }}) CXX=$(which g++-${{ env.GCC_VERSION }}) BACKEND="THREADS" python -m pip install -e . --verbose
+          python -m pip install -e . --verbose
+
       - name: Run PennyLane-Lightning-Kokkos unit tests
         run: |
           cd main/

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build and install package
         env:
-          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_CUDA=ON"
+          CMAKE_ARGS: -DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_CUDA=ON
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -49,8 +49,8 @@ jobs:
           /usr/local/cuda-11.8/bin/nvcc --version
       - name: Build and run unit tests
         env:
-          PATH: /usr/local/cuda-11.8/bin:$PATH
-          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
+          PATH: /usr/local/cuda-11.8/bin:${{ PATH }}
+          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:${{ LD_LIBRARY_PATH }}
         run: |
             cmake . -BBuild \
               -DKokkos_ENABLE_CUDA=ON \
@@ -98,8 +98,8 @@ jobs:
           CMAKE_ARGS: -DKokkos_ENABLE_CUDA=ON
           CC: gcc-${{ env.GCC_VERSION }}
           CXX: g++-${{ env.GCC_VERSION }}
-          PATH: /usr/local/cuda-11.8/bin:$PATH
-          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
+          PATH: /usr/local/cuda-11.8/bin:${{ PATH }}
+          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:${{ LD_LIBRARY_PATH }}
         run: |
           python3.8 -m pip install -e . --verbose
 

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Build and install package
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_CUDA=ON
-          CC: $(which gcc-${{ env.GCC_VERSION }})
-          CXX: $(which g++-${{ env.GCC_VERSION }})
+          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
+          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -32,7 +32,9 @@ jobs:
           python-version: '3.8'
 
       - name: Remove Ubuntu unattended upgrades
-        run: sudo apt-get remove -y -q unattended-upgrades
+        run: |
+          sudo apt --fix-broken install
+          sudo apt-get remove -y -q unattended-upgrades
 
       - name: Install required packages
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -48,17 +48,16 @@ jobs:
           nvidia-smi
           /usr/local/cuda-11.8/bin/nvcc --version
       - name: Build and run unit tests
-        env:
-          PATH: /usr/local/cuda-11.8/bin:${{ PATH }}
-          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:${{ LD_LIBRARY_PATH }}
         run: |
-            cmake . -BBuild \
-              -DKokkos_ENABLE_CUDA=ON \
-              -DKokkos_ENABLE_SERIAL=ON \
-              -DPLKOKKOS_BUILD_TESTS=ON \
-              -G Ninja
-            cmake --build ./Build
-            ./Build/pennylane_lightning_kokkos/src/tests/runner_kokkos
+          export PATH=/usr/local/cuda-11.8/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
+          cmake . -BBuild \
+            -DKokkos_ENABLE_CUDA=ON \
+            -DKokkos_ENABLE_SERIAL=ON \
+            -DPLKOKKOS_BUILD_TESTS=ON \
+            -G Ninja
+          cmake --build ./Build
+          ./Build/pennylane_lightning_kokkos/src/tests/runner_kokkos
       - name: Cleanup
         if: always()
         run: |
@@ -98,9 +97,9 @@ jobs:
           CMAKE_ARGS: -DKokkos_ENABLE_CUDA=ON
           CC: gcc-${{ env.GCC_VERSION }}
           CXX: g++-${{ env.GCC_VERSION }}
-          PATH: /usr/local/cuda-11.8/bin:${{ PATH }}
-          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:${{ LD_LIBRARY_PATH }}
         run: |
+          export PATH=/usr/local/cuda-11.8/bin:$PATH
+          export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
           python3.8 -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           export PATH=/usr/local/cuda-11.8/bin:$PATH
           export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
-          python3.8 -m pip install -e . --verbose
+          python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests
         env:

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Remove Ubuntu unattended upgrades
         run: |
-          sudo apt --fix-broken install
-          sudo apt-get remove -y -q unattended-upgrades
+          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken install
+          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken install
 
       - name: Install required packages
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and install package
-        env: |
+        env:
           CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_CUDA=ON"
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install ninja cmake~=3.24.3
+          python3.8 -m pip install ninja cmake~=3.24.3
       - name: Checkout PennyLane-Lightning-Kokkos
         uses: actions/checkout@v3
 
@@ -48,9 +48,10 @@ jobs:
           nvidia-smi
           /usr/local/cuda-11.8/bin/nvcc --version
       - name: Build and run unit tests
+        env:
+          PATH: /usr/local/cuda-11.8/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |
-            export PATH=/usr/local/cuda-11.8/bin:$PATH
-            export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
             cmake . -BBuild \
               -DKokkos_ENABLE_CUDA=ON \
               -DKokkos_ENABLE_SERIAL=ON \
@@ -83,11 +84,11 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
-          python -m pip install pip~=22.3
-          python -m pip install ninja cmake~=3.24.3 pytest pytest-mock flaky pytest-cov wheel
+          python3.8 -m pip install pip~=22.3
+          python3.8 -m pip install ninja cmake~=3.24.3 pytest pytest-mock flaky pytest-cov wheel
           # Sync with latest master branches
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-          python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
+          python3.8 -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          python3.8 -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
           
       - name: Checkout pennyLane-lightning-kokkos
         uses: actions/checkout@v3
@@ -100,9 +101,11 @@ jobs:
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |
-          python -m pip install -e . --verbose
+          python3.8 -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests
+        env:
+          OMP_PROC_BIND: false
         run: |
           pytest ./tests/
           pl-device-test --device lightning.kokkos --skip-ops --shots=20000

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -93,10 +93,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and install package
+        env: |
+          CMAKE_ARGS: "-DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_CUDA=ON"
+          PATH: /usr/local/cuda-11.8/bin:$PATH
+          LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |
-          export PATH=/usr/local/cuda-11.8/bin:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
-          CC=$(which gcc-${{ env.GCC_VERSION }}) CXX=$(which g++-${{ env.GCC_VERSION }}) BACKEND="CUDA" python -m pip install -e . --verbose
+          python -m pip install -e . --verbose
 
       - name: Run PennyLane-Lightning-Kokkos unit tests
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Build and install package
         env:
           CMAKE_ARGS: -DKokkos_ENABLE_CUDA=ON
-          CC: ${{ which gcc-${{ env.GCC_VERSION }} }}
-          CXX: ${{ which g++-${{ env.GCC_VERSION }} }}
+          CC: gcc-${{ env.GCC_VERSION }}
+          CXX: g++-${{ env.GCC_VERSION }}
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -33,13 +33,16 @@ jobs:
 
       - name: Remove Ubuntu unattended upgrades
         run: |
-          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken -y install
-          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken -y install
+          sudo apt-get remove -y -q unattended-upgrades
 
       - name: Install required packages
         run: |
+          sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
+          sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
+          sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           python3.8 -m pip install ninja cmake~=3.24.3
+
       - name: Checkout PennyLane-Lightning-Kokkos
         uses: actions/checkout@v3
 

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
-          sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
-          sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov | apt --fix-broken install | \
           sudo apt-get update && sudo apt-get -y -q install gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
           python3.8 -m pip install ninja cmake~=3.24.3
 

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Remove Ubuntu unattended upgrades
         run: |
-          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken install
-          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken install
+          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken -y install
+          sudo apt-get remove -y -q unattended-upgrades | sudo apt --fix-broken -y install
 
       - name: Install required packages
         run: |

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Build and install package
         env:
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=$(which gcc-${{ env.GCC_VERSION }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ env.GCC_VERSION }}) -DKokkos_ENABLE_CUDA=ON
+          CMAKE_ARGS: -DKokkos_ENABLE_CUDA=ON
+          CC: $(which gcc-${{ env.GCC_VERSION }})
+          CXX: $(which g++-${{ env.GCC_VERSION }})
           PATH: /usr/local/cuda-11.8/bin:$PATH
           LD_LIBRARY_PATH: /usr/local/cuda-11.8/lib64:$LD_LIBRARY_PATH
         run: |

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -91,6 +91,8 @@ jobs:
           python setup.py build_ext -i --define="Kokkos_ENABLE_${{ matrix.exec_model }}=ON;CMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++"
           pip install -e .
       - name: Run PennyLane-Lightning unit tests
+        env:
+          OMP_PROC_BIND: false
         run: |
           cd main/
           pytest tests/

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -76,7 +76,7 @@ jobs:
             source /opt/rh/devtoolset-11/enable -y
 
           CIBW_ENVIRONMENT: |
-            PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH BACKEND=${{ matrix.exec_model }}
+            PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH BACKEND=${{ matrix.exec_model }} CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python)"
           
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -76,7 +76,7 @@ jobs:
             source /opt/rh/devtoolset-11/enable -y
 
           CIBW_ENVIRONMENT: |
-            PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH BACKEND=${{ matrix.exec_model }} CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python)"
+            PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python) -DKokkos_ENABLE_${{ matrix.exec_model }}=ON"
           
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -86,11 +86,13 @@ jobs:
             python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
           CIBW_TEST_COMMAND: |
-            OMP_PROC_BIND=false pl-device-test --device=lightning.kokkos --skip-ops -x --tb=short --no-flaky-report
+            pl-device-test --device=lightning.kokkos --skip-ops -x --tb=short --no-flaky-report
           
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
           CIBW_BUILD_VERBOSITY: 3
+
+          OMP_PROC_BIND: false
 
         run: 
           python3.8 -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -86,7 +86,7 @@ jobs:
             python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
           CIBW_TEST_COMMAND: |
-            pl-device-test --device=lightning.kokkos --skip-ops -x --tb=short --no-flaky-report
+            OMP_PROC_BIND=false pl-device-test --device=lightning.kokkos --skip-ops -x --tb=short --no-flaky-report
           
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -131,8 +131,6 @@ jobs:
 
       - name: Build wheels
         env:
-          CMAKE_ARGS: "-DPYTHON_EXECUTABLE=$(which python)"
-
           CIBW_BUILD: ${{ matrix.cibw_build }}
 
           # MacOS specific build settings
@@ -143,6 +141,9 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             python -m pip install pybind11 ninja cmake~=3.24.0 setuptools
+
+          CIBW_ENVIRONMENT: |
+            CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python)"
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -131,6 +131,8 @@ jobs:
 
       - name: Build wheels
         env:
+          CMAKE_ARGS: "-DPYTHON_EXECUTABLE=$(which python)"
+
           CIBW_BUILD: ${{ matrix.cibw_build }}
 
           # MacOS specific build settings

--- a/README.rst
+++ b/README.rst
@@ -15,30 +15,43 @@ learning, automatic differentiation, and optimization of hybrid quantum-classica
 Installation
 ============
 
+We suggest first installing Kokkos with the wanted configuration following the instruction found in the `Kokkos documentation <https://kokkos.github.io/kokkos-core-wiki/building.html>`_.
+Next, append the install location to ``CMAKE_PREFIX_PATH``.
+If an installation is not found, our builder will install it from scratch nevertheless.
+
+The simplest way to install PennyLane-Lightning-Kokkos (OpenMP backend) is using ``pip``.
+
 .. code-block:: console
 
-   cmake -Bbuild -DKokkos_ENABLE_OPENMP=On -DPLKOKKOS_BUILD_TESTS=On -G Ninja
-   cmake --build ./build
+   CMAKE_ARGS="-DKokkos_ENABLE_OPENMP=ON" python -m pip install .
 
-You can install the python interface with:
+or for an editable ``pip`` installation with:
 
 .. code-block:: console
 
-   python setup.py build_ext --backend="OPENMP"
+   CMAKE_ARGS="-DKokkos_ENABLE_OPENMP=ON" python -m pip install -e .
+
+Alternatively, you can install the python interface with:
+
+.. code-block:: console
+
+   CMAKE_ARGS="-DKokkos_ENABLE_OPENMP=ON" python setup.py build_ext
    python setup.py bdist_wheel
    pip install ./dist/PennyLane*.whl --force-reinstall
 
-
-or for an editable `pip` installation with:
+To build the plugin directly with CMake:
 
 .. code-block:: console
 
-   BACKEND="OPENMP" python -m pip install -e .
+   cmake -B build -DKokkos_ENABLE_OPENMP=ON -DPLKOKKOS_BUILD_TESTS=ON -G Ninja
+   cmake --build build
 
-
-Supported backend options are "SERIAL", "OPENMP", "THREADS", "HIP" and "CUDA". For "HIP" and "CUDA", the appropriate software stacks are required to enable compilation and subsequent use.
-For explicit targeting of a given supported architecture, the environment variable `ARCH` can also be specified which directly sets the `-DKokkos_ARCH_{...}=ON` build option. Note that "THREADS"
-backend is not recommended since `Kokkos <https://github.com/kokkos/kokkos-core-wiki/blob/17f08a6483937c26e14ec3c93a2aa40e4ce081ce/docs/source/ProgrammingGuide/Initialization.md?plain=1#L67>`_ does not guarantee its safety.
+Supported backend options are "SERIAL", "OPENMP", "THREADS", "HIP" and "CUDA" and the corresponding build switches are ``-DKokkos_ENABLE_BACKEND=ON``, where one needs to replace ``BACKEND``.
+One can activate simultaneously one serial, one parallel host and one parallel host backend, but not two of any category at the same time.
+For "HIP" and "CUDA", the appropriate software stacks are required to enable compilation and subsequent use.
+Similarly, the CMake option ``-DKokkos_ARCH_{...}=ON`` must also be specified to target a given architecture.
+A list of the architectures is found on the `Kokkos wiki <https://github.com/kokkos/kokkos/wiki/Macros#architectures>`_.
+Note that "THREADS" backend is not recommended since `Kokkos <https://github.com/kokkos/kokkos-core-wiki/blob/17f08a6483937c26e14ec3c93a2aa40e4ce081ce/docs/source/ProgrammingGuide/Initialization.md?plain=1#L67>`_ does not guarantee its safety.
 
 .. installation-end-inclusion-marker-do-not-remove
 
@@ -57,25 +70,25 @@ Next, within the container, we install the ROCm software stack:
 
     yum install -y https://repo.radeon.com/amdgpu-install/21.40.2/rhel/7.9/amdgpu-install-21.40.2.40502-1.el7.noarch.rpm
     amdgpu-install --usecase=hiplibsdk,rocm --no-dkms
-    
+
 We next build the test-suite, with a given AMD GPU target in mind, as listed `here <https://github.com/kokkos/kokkos/blob/master/Makefile.kokkos>`_.
 
 .. code-block:: console
 
     cd /io
-    export PATH=$PATH:/opt/rocm/bin/ 
+    export PATH=$PATH:/opt/rocm/bin/
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib
-    export CXX=/opt/rocm/hip/bin/hipcc 
-    cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/rocm/hip/bin/hipcc -DKokkos_ENABLE_HIP=on -DPLKOKKOS_BUILD_TESTS=On -DKokkos_ARCH_VEGA90A=ON
-    cmake --build ./build --verbose
+    export CXX=/opt/rocm/hip/bin/hipcc
+    cmake -B build -DCMAKE_CXX_COMPILER=/opt/rocm/hip/bin/hipcc -DKokkos_ENABLE_HIP=ON -DPLKOKKOS_BUILD_TESTS=ON -DKokkos_ARCH_VEGA90A=ON
+    cmake --build build --verbose
 
-We may now leave the container, and run the built test-suite on a machine with access to the targetted GPU.
+We may now leave the container, and run the built test-suite on a machine with access to the targeted GPU.
 
-For a system with access to the ROCm stack outside of a manylinux container, an editable `pip` installation can be built and installed as:
+For a system with access to the ROCm stack outside of a manylinux container, an editable ``pip`` installation can be built and installed as:
 
 .. code-block:: console
 
-   BACKEND="HIP" ARCH="VEGA90A" python -m pip install -e .
+   CMAKE_ARGS="-DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_VEGA90A=ON" python -m pip install -e .
 
 
 .. support-start-inclusion-marker-do-not-remove
@@ -98,7 +111,7 @@ License
 =======
 
 The PennyLane-Lightning-Kokkos plugin is **free** and **open source**, released under
-the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. 
+the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_.
 The PennyLane-Lightning-Kokkos plugin makes use of the `Kokkos <https://github.com/kokkos/kokkos>`__ library, which is held to their own respective licenses.
 
 .. license-end-inclusion-marker-do-not-remove

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To build the plugin directly with CMake:
    cmake --build build
 
 Supported backend options are "SERIAL", "OPENMP", "THREADS", "HIP" and "CUDA" and the corresponding build switches are ``-DKokkos_ENABLE_BACKEND=ON``, where one needs to replace ``BACKEND``.
-One can activate simultaneously one serial, one parallel host and one parallel host backend, but not two of any category at the same time.
+One can activate simultaneously one serial, one parallel CPU host (e.g. "OPENMP", "THREADS") and one parallel GPU device backend (e.g. "HIP", "CUDA"), but not two of any category at the same time.
 For "HIP" and "CUDA", the appropriate software stacks are required to enable compilation and subsequent use.
 Similarly, the CMake option ``-DKokkos_ARCH_{...}=ON`` must also be specified to target a given architecture.
 A list of the architectures is found on the `Kokkos wiki <https://github.com/kokkos/kokkos/wiki/Macros#architectures>`_.

--- a/setup.py
+++ b/setup.py
@@ -84,13 +84,13 @@ if not os.getenv("READTHEDOCS"):
                 ]  # only build with Clang under Windows
             elif platform.system() not in ["Darwin", "Linux"]:
                 raise RuntimeError(f"Unsupported '{platform.system()}' platform")
-            
+
             if not Path(self.build_temp).exists():
                 os.makedirs(self.build_temp)
-            
+
             if "CMAKE_ARGS" not in os.environ.keys():
                 os.environ["CMAKE_ARGS"] = ""
-                
+
             subprocess.check_call(
                 ["cmake"]
                 + os.environ["CMAKE_ARGS"].split(" ")
@@ -121,7 +121,9 @@ info = {
     "url": "https://github.com/PennyLaneAI/pennylane-lightning-kokkos",
     "license": "Apache License 2.0",
     "packages": find_packages(where="."),
-    "package_data": {"pennylane_lightning_kokkos": ["src/*"]},
+    "package_data": {
+        "pennylane_lightning_kokkos": [os.path.join("src", "*"), os.path.join("src", "**", "*")]
+    },
     "entry_points": {
         "pennylane.plugins": [
             "lightning.kokkos = pennylane_lightning_kokkos:LightningKokkos",

--- a/setup.py
+++ b/setup.py
@@ -37,17 +37,11 @@ if not os.getenv("READTHEDOCS"):
         user_options = build_ext.user_options + [
             ("define=", "D", "Define variables for CMake"),
             ("verbosity", "V", "Increase CMake build verbosity"),
-            ("backend=", "B", "Define compiled Kokkos backend"),
-            ("arch=", "A", "Define backend targetted architecture"),
         ]
-
-        backends = {"CUDA", "HIP", "OPENMP", "THREADS", "SERIAL"}
 
         def initialize_options(self):
             super().initialize_options()
             self.define = None
-            self.backend = None
-            self.arch = None
             self.verbosity = ""
 
         def finalize_options(self):
@@ -84,13 +78,11 @@ if not os.getenv("READTHEDOCS"):
                 ]
 
             # Add more platform dependent options
-            if platform.system() == "Darwin":
-                pass
-            elif platform.system() == "Windows":
+            if platform.system() == "Windows":
                 configure_args += [
                     "-DKokkos_ENABLE_OPENMP=OFF"
                 ]  # only build with Clang under Windows
-            elif platform.system() != "Linux":
+            elif platform.system() not in ["Darwin", "Linux"]:
                 raise RuntimeError(f"Unsupported '{platform.system()}' platform")
             
             if not Path(self.build_temp).exists():

--- a/setup.py
+++ b/setup.py
@@ -83,19 +83,6 @@ if not os.getenv("READTHEDOCS"):
                     f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
                 ]
 
-            if os.getenv("BACKEND") and not self.backend:
-                self.backend = os.getenv("BACKEND")
-            if os.getenv("ARCH") and not self.arch:
-                self.arch = os.getenv("ARCH")
-
-            if self.backend:
-                if self.backend in self.backends:
-                    configure_args.append(f"-DKokkos_ENABLE_{self.backend}=ON")
-                else:
-                    raise RuntimeError(f"Unsupported backend: '{self.backend}'")
-                if self.arch:
-                    configure_args.append(f"-DKokkos_ARCH_{self.arch}=ON")
-
             # Add more platform dependent options
             if platform.system() == "Darwin":
                 pass
@@ -106,11 +93,6 @@ if not os.getenv("READTHEDOCS"):
             elif platform.system() != "Linux":
                 raise RuntimeError(f"Unsupported '{platform.system()}' platform")
             
-            for var, opt in zip(["CC", "CXX"], ["C", "CXX"]):
-                if os.getenv(var):
-                    tmp = os.getenv(var)
-                    configure_args += [f"-DCMAKE_{opt}_COMPILER={tmp}"]
-                    
             if not Path(self.build_temp).exists():
                 os.makedirs(self.build_temp)
             

--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,9 @@ if not os.getenv("READTHEDOCS"):
             cfg = "Debug" if debug else "Release"
             ninja_path = str(shutil.which("ninja"))
 
-            # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
             configure_args = [
                 "-DCMAKE_CXX_FLAGS=-fno-lto",
                 f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
-                f"-DPYTHON_EXECUTABLE={sys.executable}",
                 f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
                 *(self.cmake_defines),
             ]
@@ -100,27 +98,7 @@ if not os.getenv("READTHEDOCS"):
 
             # Add more platform dependent options
             if platform.system() == "Darwin":
-                # To support ARM64
-                if os.getenv("ARCHS") == "arm64":
-                    configure_args += [
-                        "-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11",
-                        "-DCMAKE_SYSTEM_NAME=Darwin",
-                        "-DCMAKE_SYSTEM_PROCESSOR=ARM64",
-                    ]
-                else:  # X64 arch
-                    if shutil.which("brew"):
-                        llvmpath = (
-                            subprocess.check_output(["brew", "--prefix", "llvm"]).decode().strip()
-                        )
-                    else:
-                        llvmpath = shutil.which("clang++")
-                        llvmpath = Path(llvmpath).parent.parent
-                    configure_args += [
-                        f"-DCMAKE_CXX_COMPILER={llvmpath}/bin/clang++",
-                        f"-DCMAKE_LINKER={llvmpath}/bin/lld",
-                    ]  # Use clang instead of appleclang
-                # Disable OpenMP in M1 Macs
-                configure_args += ["-DKokkos_ENABLE_OPENMP=OFF"]
+                pass
             elif platform.system() == "Windows":
                 configure_args += [
                     "-DKokkos_ENABLE_OPENMP=OFF"
@@ -135,9 +113,18 @@ if not os.getenv("READTHEDOCS"):
                 os.makedirs(self.build_temp)
 
             subprocess.check_call(
-                ["cmake", str(ext.sourcedir)] + configure_args, cwd=self.build_temp
+                ["cmake"]
+                + os.environ["CMAKE_ARGS"].split(" ")
+                + [str(ext.sourcedir)]
+                + configure_args,
+                cwd=self.build_temp,
+                env=os.environ,
             )
-            subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
+            subprocess.check_call(
+                ["cmake", "--build", ".", "--verbose"] + build_args,
+                cwd=self.build_temp,
+                env=os.environ,
+            )
 
 
 with open("pennylane_lightning_kokkos/_version.py") as f:


### PR DESCRIPTION
**Context:**
The way `setup.py` is written, it tries to find binaries in the environment (for MacOS in particular) and it may override some CMake decisions which would actually make sense in some build environments (e.g. on Conda-Forge). This is trying to apply [this patch](https://github.com/conda-forge/staged-recipes/pull/22360/files#diff-94bb2a39daa62e2f003068e42c7e4347e0f08fe0d54040c79cf89e233377ddd9) and a bit more. 

**Description of the Change:**
Remove (most of ) CMake argument parsing from `setup.py`. Adapt CI files and use `env:` when possible to set environment variables. 

**Benefits:**
Where necessary, libraries and default build tools are defined declaratively in the Actions files. `setup.py` is simplified and any CMake argument can be passed in `CMAKE_ARGS` if required. This complies better with Conda-Forge, and hence we'll be able to remove some patches there.

**Possible Drawbacks:**
Building from source may change a bit for users used to do so.

**Related GitHub Issues:**
