### PR TITLE
Use `Operator.name` instead of `Operation.base_name`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Remove logic from `setup.py` and transfer paths and definitions into workflow files.
 [(#58)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/58)
 
+* Use `Operator.name` instead of `Operation.base_name`
+
 ### Documentation
 
 ### Bug fixes
@@ -26,7 +28,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Vincent Michaud-Rioux
+Christina Lee, Vincent Michaud-Rioux
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,7 +18,8 @@
 * Remove logic from `setup.py` and transfer paths and definitions into workflow files.
 [(#58)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/58)
 
-* Use `Operator.name` instead of `Operation.base_name`
+* Use `Operator.name` instead of `Operation.base_name`.
+  [(#67)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/67)
 
 ### Documentation
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -370,7 +370,7 @@ if CPP_BINARY_AVAILABLE:
             invert_param = False
 
             for o in operations:
-                if o.base_name in skipped_ops:
+                if o.name in skipped_ops:
                     continue
                 name = o.name
                 if isinstance(o, Adjoint):

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -370,7 +370,7 @@ if CPP_BINARY_AVAILABLE:
             invert_param = False
 
             for o in operations:
-                if o.name in skipped_ops:
+                if str(o.name) in skipped_ops:
                     continue
                 name = o.name
                 if isinstance(o, Adjoint):


### PR DESCRIPTION
Context:

`Operation.base_name` is a holdover from when in-place inversion modified the name of the object. Since in-place inversion is removed, there is no reason to keep base_name around any longer. `Opeartor.name` does exactly the same thing.

Description of the Change:

Use `Operator.name` instead of `Operation.base_name`

Benefits:

PennyLane can deprecate `Operation.base_name`.

Possible Drawbacks:

None

Related GitHub Issues: