### PR TITLE
Add tag on release workflow

### DIFF
--- a/.github/workflows/post_release_tag.yml
+++ b/.github/workflows/post_release_tag.yml
@@ -1,0 +1,31 @@
+name: Automated Latest Release Tag
+
+on:
+  release:
+    types: [published]
+
+env:
+  TAG_NAME: latest_release
+
+jobs:
+  post_release_tag_latest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PennyLane-Lightning-Kokkos
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Overwrite tag
+        run: |
+          git config --local user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --local user.name "Latest tag update bot"
+          git tag -d $TAG_NAME || true
+          if git push --delete origin $TAG_NAME; then
+            echo "Remove tag $TAG_NAME from remote."
+          else
+            echo "$TAG_NAME does not exist in remote. Just proceed."
+          fi
+          git tag $TAG_NAME
+          git push --tags


### PR DESCRIPTION
**Context:** This PR ensures that `lightning.kokkos` releases are tagged with the dynamically updated `latest_release` tag for each release cycle.

**Description of the Change:** As above.

**Benefits:** Ensures sync across projects.

**Possible Drawbacks:**

**Related GitHub Issues:**
