### PR TITLE
Sc 40238 kokkos pl plugin test onboard

### DIFF
--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -11,13 +11,13 @@ jobs:
     name: Lightning-Kokkos Compatibility test (tests_linux) - latest/latest
     uses: ./.github/workflows/tests_linux.yml
     with:
-      lightning-gpu-version: latest
+      lightning-kokkos-version: latest
       pennylane-version: latest
 
   tests_linux_x86_nvidia_gpu:
     name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - latest/latest
     uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
     with:
-      lightning-gpu-version: latest
+      lightning-kokkos-version: latest
       pennylane-version: latest
 

--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - latest/latest
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-latest-latest.yml
+++ b/.github/workflows/compat-check-latest-latest.yml
@@ -1,0 +1,23 @@
+name: Compat Check w/PL - latest/latest
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux:
+    name: Lightning-Kokkos Compatibility test (tests_linux) - latest/latest
+    uses: ./.github/workflows/tests_linux.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: latest
+
+  tests_linux_x86_nvidia_gpu:
+    name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - latest/latest
+    uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: latest
+

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -1,0 +1,23 @@
+name: Compat Check w/PL - latest/stable
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux:
+    name: Lightning-Kokkos Compatibility test (tests_linux) - latest/stable
+    uses: ./.github/workflows/tests_linux.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: stable
+
+  tests_linux_x86_nvidia_gpu:
+    name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - latest/stable
+    uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
+    with:
+      lightning-gpu-version: latest
+      pennylane-version: stable
+

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -11,13 +11,13 @@ jobs:
     name: Lightning-Kokkos Compatibility test (tests_linux) - latest/stable
     uses: ./.github/workflows/tests_linux.yml
     with:
-      lightning-gpu-version: latest
+      lightning-kokkos-version: latest
       pennylane-version: stable
 
   tests_linux_x86_nvidia_gpu:
     name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - latest/stable
     uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
     with:
-      lightning-gpu-version: latest
+      lightning-kokkos-version: latest
       pennylane-version: stable
 

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - latest/stable
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -11,13 +11,13 @@ jobs:
     name: Lightning-Kokkos Compatibility test (tests_linux) - stable/latest
     uses: ./.github/workflows/tests_linux.yml
     with:
-      lightning-gpu-version: stable
+      lightning-kokkos-version: stable
       pennylane-version: latest
 
   tests_linux_x86_nvidia_gpu:
     name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - stable/latest
     uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
     with:
-      lightning-gpu-version: stable
+      lightning-kokkos-version: stable
       pennylane-version: latest
 

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -1,0 +1,23 @@
+name: Compat Check w/PL - stable/latest
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux:
+    name: Lightning-Kokkos Compatibility test (tests_linux) - stable/latest
+    uses: ./.github/workflows/tests_linux.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: latest
+
+  tests_linux_x86_nvidia_gpu:
+    name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - stable/latest
+    uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: latest
+

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - stable/latest
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -1,0 +1,23 @@
+name: Compat Check w/PL - stable/stable
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
+  workflow_dispatch:
+
+jobs:
+  tests_linux:
+    name: Lightning-Kokkos Compatibility test (tests_linux) - stable/stable
+    uses: ./.github/workflows/tests_linux.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: stable
+
+  tests_linux_x86_nvidia_gpu:
+    name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - stable/stable
+    uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
+    with:
+      lightning-gpu-version: stable
+      pennylane-version: stable
+

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -1,7 +1,6 @@
 name: Compat Check w/PL - stable/stable
 
 on:
-  pull_request:
   schedule:
     - cron: "0 3 * * 1-5"  # Run daily at 3am Mon-Fri
   workflow_dispatch:

--- a/.github/workflows/compat-check-stable-stable.yml
+++ b/.github/workflows/compat-check-stable-stable.yml
@@ -11,13 +11,13 @@ jobs:
     name: Lightning-Kokkos Compatibility test (tests_linux) - stable/stable
     uses: ./.github/workflows/tests_linux.yml
     with:
-      lightning-gpu-version: stable
+      lightning-kokkos-version: stable
       pennylane-version: stable
 
   tests_linux_x86_nvidia_gpu:
     name: Lightning-Kokkos Compatibility test (tests_linux_x86_nvidia_gpu) - stable/stable
     uses: ./.github/workflows/tests_linux_x86_nvidia_gpu.yml
     with:
-      lightning-gpu-version: stable
+      lightning-kokkos-version: stable
       pennylane-version: stable
 

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -13,7 +13,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  #pull_request:
 
 env:
   PY_VERSION: 3.8

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -1,5 +1,15 @@
 name: Testing (Linux)
 on:
+  workflow_call:
+    inputs:
+      lightning-kokkos-version:
+        type: string
+        required: true
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+      pennylane-version:
+        type: string
+        required: true
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   push:
     branches:
       - master
@@ -11,30 +21,36 @@ env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning_kokkos --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native"
   OMP_NUM_THREADS: "2"
 
+concurrency:
+  group: cpu-tests-${{ github.ref }}-${{ inputs.lightning-kokkos-version }}-${{ inputs.pennylane-version }}
+  cancel-in-progress: true
+
 jobs:
   cpptests_openmp:
     name: C++ tests (Linux) for OpenMP Kokkos backend
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
+    runs-on: ubuntu-22.04
+
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
+      - uses: actions/checkout@v3
         with:
-          access_token: ${{ github.token }}
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '${{ env.PY_VERSION }}'
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2 # for codecov
-
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests
         env:
@@ -47,17 +63,19 @@ jobs:
 
   pythontests_openmp:
     name: Python tests for OpenMP Kokkos Backend
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout PennyLane-Lightning-Kokkos
         uses: actions/checkout@v3
         with:
           path: main
-          fetch-depth: 2
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -67,12 +85,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} ninja-build
 
+      - name: Install Latest PennyLane
+        # We want to install the latest PL on non workflow_call events
+        if: inputs.pennylane-version == 'latest'  || inputs.pennylane-version == ''
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Get required Python packages
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          python -m pip uninstall pennylane -y
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
@@ -100,22 +121,27 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
+      - name: Checkout PennyLane-Lightning-Kokkos
+        uses: actions/checkout@v3
         with:
-          access_token: ${{ github.token }}
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '${{ env.PY_VERSION }}'
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2 # for codecov
-
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests
         run: |
@@ -135,7 +161,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-          fetch-depth: 2
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -145,12 +172,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} ninja-build
 
+      - name: Install Latest PennyLane
+        # We want to install the latest PL on non workflow_call events
+        if: inputs.pennylane-version == 'latest'  || inputs.pennylane-version == ''
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Get required Python packages
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          python -m pip uninstall pennylane -y
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device
@@ -177,22 +207,27 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
+      - name: Checkout PennyLane-Lightning-Kokkos
+        uses: actions/checkout@v3
         with:
-          access_token: ${{ github.token }}
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '${{ env.PY_VERSION }}'
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2 # for codecov
-
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} gcovr lcov
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests
         run: |
@@ -211,7 +246,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: main
-          fetch-depth: 2
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -221,12 +261,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} ninja-build
 
+      - name: Install Latest PennyLane
+        # We want to install the latest PL on non workflow_call events
+        if: inputs.pennylane-version == 'latest'  || inputs.pennylane-version == ''
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Get required Python packages
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-mock flaky
-          python -m pip uninstall pennylane -y
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Install lightning.kokkos device

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Switch to stable build of Lightning-Kokkos
         if: inputs.lightning-kokkos-version == 'stable'
-        run: git checkout $(git tag | sort -V | tail -1)
+        run: cd main && git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -164,6 +164,10 @@ jobs:
           # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
           fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
 
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: cd main && git checkout $(git tag | sort -V | tail -1)
+
       - uses: actions/setup-python@v4
         name: Install Python
         with:
@@ -251,7 +255,7 @@ jobs:
 
       - name: Switch to stable build of Lightning-Kokkos
         if: inputs.lightning-kokkos-version == 'stable'
-        run: git checkout $(git tag | sort -V | tail -1)
+        run: cd main && git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -13,7 +13,7 @@ on:
   push:
     branches:
       - master
-  #pull_request:
+  pull_request:
 
 env:
   PY_VERSION: 3.8

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  #pull_request:
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning_kokkos --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native" 

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -1,5 +1,15 @@
 name: Tests::Linux::x86_64::Nvidia_GPU
 on:
+  workflow_call:
+    inputs:
+      lightning-kokkos-version:
+        type: string
+        required: true
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+      pennylane-version:
+        type: string
+        required: true
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   release:
   push:
     branches:
@@ -12,7 +22,7 @@ env:
   CI_CUDA_ARCH: 86
 
 concurrency:
-  group: gpu-test-${{ github.ref }}
+  group: gpu-tests-${{ github.ref }}-${{ inputs.lightning-kokkos-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:
@@ -28,6 +38,13 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning-Kokkos
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -61,7 +78,7 @@ jobs:
           echo "Python Interpreter Path => $py_path"
           echo "python=$py_path" >> $GITHUB_OUTPUT
           
-          pip_path=$(which python)
+          pip_path=$(which pip)
           echo "PIP Path => $pip_path"
           echo "pip=$pip_path" >> $GITHUB_OUTPUT
 
@@ -73,6 +90,10 @@ jobs:
         run: |
           nvidia-smi
           /usr/local/cuda/bin/nvcc --version
+
+      - name: Install Latest PennyLane
+        if: inputs.pennylane-version == 'latest'
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Build and run unit tests
         run: |
@@ -114,6 +135,13 @@ jobs:
     steps:
       - name: Checkout pennyLane-lightning-gpu
         uses: actions/checkout@v3
+        with:
+          # Checkout entire git-history if workflow_call passes 'stable' as we need to find the most recent git-tag
+          fetch-depth: ${{ inputs.lightning-kokkos-version == 'stable' && 0 || 2 }}
+
+      - name: Switch to stable build of Lightning-Kokkos
+        if: inputs.lightning-kokkos-version == 'stable'
+        run: git checkout $(git tag | sort -V | tail -1)
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -152,12 +180,16 @@ jobs:
           echo "PIP Path => $pip_path"
           echo "pip=$pip_path" >> $GITHUB_OUTPUT
 
+      - name: Install Latest PennyLane
+        # We want to install the latest PL on non workflow_call events
+        if: inputs.pennylane-version == 'latest'  || inputs.pennylane-version == ''
+        run: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
       - name: Install required packages
         run: |
           python -m pip install pip~=22.3
           python -m pip install ninja cmake pytest pytest-mock flaky pytest-cov wheel
           # Sync with latest master branches
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
           python -m pip install --index-url https://test.pypi.org/simple/ pennylane-lightning --pre --force-reinstall --no-deps
 
       - name: Build and install package

--- a/.github/workflows/tests_linux_x86_nvidia_gpu.yml
+++ b/.github/workflows/tests_linux_x86_nvidia_gpu.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - main
-  #pull_request:
+  pull_request:
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning_kokkos --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native" 


### PR DESCRIPTION
**Context:**
This PR adds 4 new workflows who's result can be tracked in the plugin-test-matrix.

**Description of the Change:**
A new `workflow_call` event was added to the linux and linux_nvidia_gpu workflows. The version of lightning-kokkos and pennylane that is to be installed can now be passed. The behavior is as follows:

- lightning-kokkos-version:
  - `latest` -> The current workflow is used as-is. Since it uses the latest commit on main by default, no further changes are necessary.
  - `stable` -> The most recent git-tag is checked out.

- pennylane-version:
  - `latest` -> PennyLane is installed from master branch prior to LKokkos installation
  - `stable` -> LKokkos is installed as per normal and the version specified in requirements.txt should take over.

**Benefits:**
Adds ability to display the results of these workflows on the plugin test matrix.

**Possible Drawbacks:**

**Related GitHub Issues:**