### PR TITLE
stop mutating input to apply

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,10 +10,14 @@
 
 ### Bug fixes
 
+* `apply` no longer mutates the inputted list of operations.
+  [(#78)](https://github.com/PennyLaneAI/pennylane-lightning-kokkos/pull/78)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
+Vincent Michaud-Rioux
 
 ---
 

--- a/pennylane_lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning_kokkos/lightning_kokkos.py
@@ -409,10 +409,10 @@ if CPP_BINARY_AVAILABLE:
                     self._apply_state_vector_kokkos(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
-                    del operations[0]
+                    operations = operations[1:]
                 elif isinstance(operations[0], BasisState):
                     self._apply_basis_state_kokkos(operations[0].parameters[0], operations[0].wires)
-                    del operations[0]
+                    operations = operations[1:]
 
             for operation in operations:
                 if isinstance(operation, (QubitStateVector, BasisState)):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -231,8 +231,10 @@ class TestApply:
 
         par = np.array(par)
         qubit_device_2_wires.reset()
-        qubit_device_2_wires.apply([operation(par, wires=[0, 1])])
+        ops = [operation(par, wires=[0, 1])]
+        qubit_device_2_wires.apply(ops)
 
+        assert len(ops) == 1  # input not mutated
         assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
 
     """ operation,input,expected_output,par """


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
In Pennylane PR [#4485](https://github.com/PennyLaneAI/pennylane/pull/4485), `tape.operations` will no longer be the sum of `tape._prep` and `tape._ops`. This means any modification of the `tape.operations` list will mutate the tape itself, instead of a shallow copy of its contents.

**Description of the Change:**
We do not want to in-place modify the `operations` list anymore. So instead of using `del operations[0]`, I simply select out the contents from index one onward.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning/pull/474
